### PR TITLE
chore: post-land follow-ups — Node24 action majors + CI/dep reasoning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.os == 'ubuntu-24.04'
-        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -102,7 +102,7 @@ jobs:
       - name: Upload sarif report (Detekt)
         if: always() && matrix.os == 'macos-15'
           && (github.event_name == 'pull_request' || env.IS_DEFAULT_BRANCH == 'true')
-        uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         continue-on-error: true
         with:
           sarif_file: build/detekt-merged.sarif
@@ -111,7 +111,7 @@ jobs:
       - name: Upload sarif report (Lint)
         if: always() && matrix.os == 'macos-15'
           && (github.event_name == 'pull_request' || env.IS_DEFAULT_BRANCH == 'true')
-        uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         continue-on-error: true
         with:
           sarif_file: build/lint-merged.sarif
@@ -136,7 +136,7 @@ jobs:
       - name: Upload code coverage to Codecov
         continue-on-error: true
         if: success() || failure()
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         env:
           OS: ${{ matrix.os }}
           JAVA_VERSION: 21
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload the build report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: '${{ matrix.os }}-JDK21-build-report'
           path: |
@@ -164,7 +164,7 @@ jobs:
       - name: Perform CodeQL Analysis
         if: matrix.os == 'ubuntu-24.04'
         timeout-minutes: 6
-        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         env:
           GITHUB_DEPENDENCY_GRAPH_ENABLED: false
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           echo "RELEASE_NOTES=$notes" >> "$GITHUB_ENV"
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body_path: ${{ env.RELEASE_NOTES }}
           draft: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,9 +150,13 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   correct — keep both.
 - **`publishSnapshot` (build.yml) auto-fires on a `dev` push** when the catalogue
   version ends `-SNAPSHOT` (gated `event==push && repo==fluxo-kt/fluxo-io &&
-  ref==default_branch`). Merging to `dev` *is* a publish attempt; it reds (in
-  isolation, matrix stays green) until the five publish secrets exist. Pushing a
-  feature branch does not publish.
+  ref==default_branch`) — it reds in isolation (matrix stays green) until the five
+  publish secrets exist. Pushing a feature branch does not publish. **Trap: a `/ff`
+  land does NOT trigger it.** The fast-forward push is authored by `GITHUB_TOKEN`,
+  and GitHub suppresses workflow triggers for `GITHUB_TOKEN` pushes (recursion
+  guard) — so build.yml/publishSnapshot do not run on a `/ff` merge. Verified: dev
+  FF to a new tip produced zero build.yml runs. To actually publish a snapshot, push
+  to `dev` with a real user/PAT (or dispatch the publish manually) — not via `/ff`.
 - **dep-submission graph is an allowlist, not a denylist.**
   `DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=".*(Compile|Runtime)Classpath"` (full-
   string `String.matches`) ships only consumer-facing resolved classpaths. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,13 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   guard) — so build.yml/publishSnapshot do not run on a `/ff` merge. Verified: dev
   FF to a new tip produced zero build.yml runs. To actually publish a snapshot, push
   to `dev` with a real user/PAT (or dispatch the publish manually) — not via `/ff`.
+  When it *does* fire without secrets, the steps reading `secrets.MAVEN_CENTRAL_*`/
+  `SIGNING_*` hard-fail → the job reds meaning "secrets absent", not "publish broken"
+  (a false-red class). Proper fix *if that red becomes noise*: a preflight job emitting
+  a `has_secrets` boolean output and gating `publishSnapshot` on it (secrets are
+  unreadable in a job-level `if:`). NOT `continue-on-error` — that would mask real
+  publish failures too. Deferred deliberately: it doesn't fire on `/ff` lands, and its
+  only firing window (a real push/dispatch) coincides with secret provisioning.
 - **dep-submission graph is an allowlist, not a denylist.**
   `DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=".*(Compile|Runtime)Classpath"` (full-
   string `String.matches`) ships only consumer-facing resolved classpaths. The
@@ -165,6 +172,16 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   build tooling into the submitted graph → phantom
   `security_update_dependency_not_found` Dependabot jobs. Excluding build tooling
   from the *consumer* graph is accurate (consumers never see it), not vuln-hiding.
+- **Dependabot proposes untagged re-publishes; adopt only endorsed versions.** It
+  reads a registry's `<versions>` *list*, not `<latest>`/upstream tags, so it can
+  suggest an artifact the maintainer never blessed. Cautionary case: `com.osacky.doctor
+  0.12.1` (PR #25) — no `v0.12.1` git tag (tags jump `v0.11.0→v0.12.0`), latest GitHub
+  release is `0.12.0`, POM byte-identical to 0.12.0, published 2.5 min after it, and the
+  Plugin Portal `<latest>`/`<release>` stay at `0.12.0`: a publish-mechanics re-cut, not
+  an upgrade. Rule: before folding a dep/plugin bump, confirm a matching upstream
+  tag/release AND registry `<latest>` — else keep the endorsed version and close the PR.
+  Dep-verification checksums the bytes you declare; it does NOT catch "non-endorsed", so
+  this review is the only gate.
 - **Action pins rot.** Every remote action needs a 40-char SHA + `# vX.Y.Z`
   comment (policy-enforced); when bumping a major, verify Node-runtime compat
   (e.g. github-script v7/Node20 → v9/Node24). Pinned-action rot is real: a pinned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,27 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   that should refresh deps, run `gh workflow run dependency-submission.yml --ref dev` to
   re-submit; the 4 `.kotlin-js-store/yarn.lock` npm alerts persist regardless (GitHub
   auto-detects that lockfile; no per-path graph exclusion — inherent, benign).
+  **Stale-manifest zombie alerts (root-caused, NOT lag, NOT a broken fix):** the manual
+  re-submit produces a *clean* 42-pkg snapshot (verified: download the run's
+  `dependency_submission-dependency-submission.json` artifact — only consumer deps
+  androidx-annotation/kotlin-stdlib/jsr305/coroutines, zero bouncycastle/protobuf/commons-*/
+  httpclient), yet ~15 maven alerts persist. Reason: they sit on a *different* manifest
+  literally named **`settings.gradle.kts`** (`created_at == updated_at`, never refreshed)
+  submitted by the **old** `setup-gradle` auto-graph that the pre-modernization build.yml ran
+  on `dev` (`dependency-graph: …'generate-and-submit'…`, no allowlist → buildscript classpath
+  incl. tooling). #29 disabled that (`GITHUB_DEPENDENCY_GRAPH_ENABLED: false`) but the new
+  submitter uses a **different correlator** (`dependency_submission-dependency-submission`), so
+  it cannot overwrite the orphan. GitHub keeps the last snapshot per correlator
+  **indefinitely** and never auto-evicts when its producer stops — so the orphaned manifest's
+  alerts are zombies. To clear at the root: POST an empty snapshot to
+  `/repos/<o>/<r>/dependency-graph/snapshots` under the **old** correlator (derives as
+  `build-buildAndCheck` = old workflow `Build` + job `buildAndCheck`) so its deps read as
+  removed → alerts auto-dismiss; or dismiss the alerts `not_used` (honest — build tooling never
+  shipped, absent from the live consumer graph — but leaves the zombie manifest so a future CVE
+  on those pinned tooling versions could re-alert). Both are outward-facing security-state
+  writes → **owner decision**. Diagnose with: download the submitted artifact (ground truth,
+  not the aggregated `/dependency-graph/sbom` which merges every manifest incl. orphans), and
+  `gh api …/dependabot/alerts --jq '…manifest_path…'`.
 - **Dependabot proposes untagged re-publishes; adopt only endorsed versions.** It
   reads a registry's `<versions>` *list*, not `<latest>`/upstream tags, so it can
   suggest an artifact the maintainer never blessed. Cautionary case: `com.osacky.doctor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,15 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   build tooling into the submitted graph → phantom
   `security_update_dependency_not_found` Dependabot jobs. Excluding build tooling
   from the *consumer* graph is accurate (consumers never see it), not vuln-hiding.
+  **Effectiveness gotcha (same GITHUB_TOKEN root as publishSnapshot):** the submitted
+  graph only refreshes when `dependency-submission.yml` actually runs (`push` to `dev` /
+  `workflow_dispatch` / Mon cron). A `/ff` land is GITHUB_TOKEN-authored → no `push`
+  trigger → the graph stays **stale**, so old Security-tab alerts linger even after the
+  in-tree fix (observed post-#29: build-tooling alerts + an assertj-core HIGH flagging
+  `<=3.27.6` though the catalogue was already on the patched `3.27.7`). After any `/ff`
+  that should refresh deps, run `gh workflow run dependency-submission.yml --ref dev` to
+  re-submit; the 4 `.kotlin-js-store/yarn.lock` npm alerts persist regardless (GitHub
+  auto-detects that lockfile; no per-path graph exclusion — inherent, benign).
 - **Dependabot proposes untagged re-publishes; adopt only endorsed versions.** It
   reads a registry's `<versions>` *list*, not `<latest>`/upstream tags, so it can
   suggest an artifact the maintainer never blessed. Cautionary case: `com.osacky.doctor


### PR DESCRIPTION
Post-land batch (off `dev` @ `55b8948`). Folds dependabot **#30** and supersedes **#25**.

### Commits
1. **`docs:` publishSnapshot trigger correction** — a `/ff` land does **not** fire `publishSnapshot` (the FF push is GITHUB_TOKEN-authored → GitHub's recursion-guard suppresses triggers). Snapshot publishing needs a real user/PAT push to `dev` or a manual dispatch. (Rescues a stranded local-only doc-note.)
2. **`ci(deps):` github-actions group → Node24 majors** (folds #30):
   - `github/codeql-action` v3.35.5 → **v4.36.1**
   - `codecov/codecov-action` v5.5.4 → **v6.0.1**
   - `actions/upload-artifact` v4.6.2 → **v7.0.1**
   - `softprops/action-gh-release` v2.6.2 → **v3.0.0**
   All four are Node20→Node24 runtime majors, compatible with this repo's GitHub-hosted runners. Each pinned commit-SHA **independently verified** against the upstream tag (annotated tags for codeql/codecov dereferenced via `git/tags`). No repo-specific breakage: no `add-snippets` in use (removed in codeql v4); upload-artifact v7 `archive` defaults `true` (back-compat).
3. **`docs:` reasoning capture** — doctor untagged-republish + publishSnapshot false-red class.

### doctor 0.12.1 (#25) — REJECTED, keep 0.12.0
Investigation: **no `v0.12.1` upstream tag** (tags jump `v0.11.0→v0.12.0`), latest GitHub release is `0.12.0`, **POM byte-identical** to 0.12.0, published **2.5 min after** it, and the Plugin Portal `<latest>`/`<release>` stay at `0.12.0`. It's a publish-mechanics re-cut, not an upgrade. Adopting it would pin a dep-verification checksum to a non-endorsed artifact for zero benefit. → close #25, no catalogue change.

### Land
`--ff-only` via `/ff`. `origin/dev` is an ancestor of HEAD (clean fast-forward). On land: close #25 and #30; FF `main` → `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use latest versions for CodeQL, Codecov, artifact upload, and release tools.

* **Documentation**
  * Enhanced CI and security operations guidance with additional edge cases and troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->