### PR TITLE
fix(rad): make AccessorAwareRad.close() idempotent per holder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,15 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `subsection()` calls `retain()` on the underlying
   `SharedDataAccessor`; closing decrements; resource frees on the last
   close. **Each subsection MUST be closed independently** — otherwise the
-  underlying handle leaks.
+  underlying handle leaks. Conversely, **`close()` is idempotent per holder**
+  (`AccessorAwareRad` has a private atomicfu `closed` guard, `final` override):
+  a holder owns exactly one retain, so it must release at most once. Without the
+  guard a `Closeable`-legal double-close (`use{}` + manual, defensive close)
+  would decrement the *shared* refcount twice and prematurely free the resource
+  still used by the parent/siblings — `IOException` for file impls, a **JVM
+  `SIGABRT` use-after-free** for direct/mmap `ByteBuffer`. Regression:
+  `AbstractRandomAccessDataTest.doubleClosingSubsectionKeepsSharedResourceForParent`
+  runs across every impl, so a new RAD that drops the guard can't pass CI.
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/AccessorAwareRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/AccessorAwareRad.kt
@@ -8,6 +8,7 @@ import fluxo.io.util.calcLength
 import fluxo.io.util.checkOffsetAndCount
 import fluxo.io.util.checkPositionAndMaxLength
 import kotlin.math.min
+import kotlinx.atomicfu.atomic
 
 @ThreadSafe
 internal abstract class AccessorAwareRad<A : SharedDataAccessor>
@@ -76,7 +77,22 @@ internal constructor(
     }
 
 
-    override fun close() {
-        access.close()
+    /**
+     * Guards [close] for one-shot release. Each holder — the root or any [subsection] —
+     * owns exactly one retain on the shared [access], so it must release at most once.
+     */
+    private val closed = atomic(false)
+
+    /**
+     * Idempotent, per the [java.io.Closeable] contract ("if already closed, invoking this
+     * method has no effect"). A repeated close must NOT decrement the shared refcount again:
+     * doing so would prematurely free the resource still in use by the parent or sibling
+     * subsections — for a memory-mapped buffer that is a use-after-free that crashes the JVM,
+     * not merely an [IOException]. Final so no subclass can reintroduce the unguarded path.
+     */
+    final override fun close() {
+        if (closed.compareAndSet(expect = false, update = true)) {
+            access.close()
+        }
     }
 }

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
@@ -251,6 +251,27 @@ internal abstract class AbstractRandomAccessDataTest(
         subsection.close()
     }
 
+    /**
+     * Closing one holder more than once must be a no-op, per the [java.io.Closeable]
+     * contract ("if the stream is already closed then invoking this method has no
+     * effect"). A second close must NOT decrement the shared refcount again, else it
+     * prematurely frees the underlying resource still in use by the parent (and any
+     * sibling subsections), corrupting their reads.
+     */
+    @Test
+    fun doubleClosingSubsectionKeepsSharedResourceForParent() = runTest(timeout = DEFAULT_TIMEOUT) {
+        val subsection = rad.subsection(1, 1)
+        // Drop the stream's hold so only {rad, subsection} retain the shared accessor.
+        inputStream.close()
+
+        subsection.close()
+        subsection.close()
+
+        // The parent shares the same accessor and was never closed: it must stay usable.
+        assertEquals(1, rad.readByteAt(1))
+        assertEquals(BYTES, rad.readAllBytes())
+    }
+
     @Test
     fun inputStreamReadPastSubsection() = runTest(timeout = DEFAULT_TIMEOUT) {
         val subsection = rad.subsection(1, 2)


### PR DESCRIPTION
## Problem

`AccessorAwareRad.close()` unconditionally decremented the **shared** `SharedDataAccessor` refcount. Each RAD holder (root or `subsection()`) owns exactly one retain, but nothing stopped a holder from releasing more than once.

A **double-close** — which `java.io.Closeable` explicitly sanctions as a no-op (*"if already closed, invoking this method has no effect"*), and which `use{}` + manual / defensive-close patterns routinely produce — decremented the shared count twice. With the parent or sibling subsections still open, that **prematurely freed the shared resource**:

- file-backed impls (`FileChannel`/`RAF`/`SeekableByteChannel`/`AsyncFileChannel`/`StreamFactory`) → parent reads throw `IOException`;
- **direct / memory-mapped `ByteBuffer`** → the region is unmapped, so the parent's next read is a native **use-after-free that crashes the JVM (`SIGABRT`)**, taking down the host process.

## Root cause (proven, not inferred from symptoms)

Controlled experiment with the new test:

| run | scope | fix? | result |
|-----|-------|------|--------|
| 1 | `ArrayTest` only | no | pass (heap — no native resource) |
| 2 | all impls | **no** | **`SIGABRT` exit 134** |
| 3 | all impls | **yes** | all 30 params green |

The only variable between the crash and green is the guard → causation, not correlation.

## Fix

A private `atomicfu` `closed` guard makes each holder release the shared refcount **at most once**; `final` blocks a future subclass from reintroducing the unguarded path. Lock-free, **no public ABI change** (`internal` class), and `close()` is once-per-lifecycle so there's no hot-path cost.

## Regression gate

`AbstractRandomAccessDataTest.doubleClosingSubsectionKeepsSharedResourceForParent` double-closes a subsection then reads the parent. It lives in the shared base, so it runs across **every impl + every constructor param (30 variants)** — a new RAD that drops the guard cannot pass CI.

Full `jvmTest` (1290 tests) green; BCV `apiCheck` (JVM + KLIB ×22 targets + TS) shows no drift; detekt clean.