### PR TITLE
fix(rad): reject reads after the shared resource is freed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,37 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `SIGABRT` use-after-free** for direct/mmap `ByteBuffer`. Regression:
   `AbstractRandomAccessDataTest.doubleClosingSubsectionKeepsSharedResourceForParent`
   runs across every impl, so a new RAD that drops the guard can't pass CI.
+- **Read-after-(last-)close is guarded at the resource-owner layer, not
+  `AccessorAwareRad`.** Once the shared resource is freed (`isOpen` false), a read
+  must fail with a clean `IOException`, never touch freed state. The guard CANNOT
+  live in `AccessorAwareRad.read`/`readFrom`: per-impl perf overrides
+  (`readByteAt0`, `read(ByteBuffer,position)`, `transferTo`) bypass it and hit
+  `access`/`access.api` directly. It lives in `SharedDataAccessor.checkOpen()`
+  (`internal` extension in `commonJvmMain` — the common `expect class IOException`
+  has no message ctor, and the hazard is JVM-only). Only **ByteBuffer** (mmap/direct
+  → native use-after-free **SIGABRT** after unmap) and **StreamFactory** (re-pool
+  into an already-drained pool → silent stream **leak**) need it; the 4 file/channel
+  impls self-throw `ClosedChannelException`/`IOException` on a closed handle.
+  **ByteArray is deliberately exempt** — no releasable resource, `close()` is a
+  no-op, guarding the fastest impl's hot path buys no safety (`RandomAccessDataArrayTest`
+  overrides the test to assert reads stay valid). **Concurrent close-during-read is safe by
+  construction, not by a flaky timing test:** `isOpen` flips `false` in
+  `SharedCloseable.releaseRetain()` *before* `onSharedClose()` runs (verified
+  `SharedCloseable.kt` `releaseRetain`→`onSharedClose`; locked by
+  `SharedCloseableTest.resourceReleaseObservesClosedState`), and reads share the resource
+  monitor with the release — ByteBuffer's unmap is `synchronized(api)` (this made
+  `readByteAt0` go `synchronized` — a deliberate hot-path cost for memory safety) and
+  StreamFactory rechecks `isOpen` **under the pool lock** (also where the drain runs). So no
+  interleaving lets a read touch freed state — and it's not just argued: `RadConcurrentCloseTest`
+  latch-freezes a real in-flight read mid-close (no sleeps), RED without each guard
+  (`unmapWaitsForInFlightRead` → close finishes mid-read; `streamRePooled…` → leaked stream).
+  Regression:
+  `AbstractRandomAccessDataTest.readingClosedHolderThrowsNotCrashes` runs across every impl and
+  exercises **all four** resource-touching entry points (`readByteAt`, `readFrom`,
+  `read(ByteBuffer)`, `transferTo`) — RED-bisected, so dropping the guard from any one override
+  reds it (covering fewer paths would let a UAF leak through the rest). NB: this rejects reads
+  after the *shared* resource is freed, NOT per-holder — reading a closed subsection whose
+  parent is still open succeeds (by design).
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks
@@ -111,7 +142,12 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
    `getSubsection0` returns `FooRad(access, globalPosition, length)` —
    same `access`, parent retains.
 2. Optional perf overrides: `read(ByteBuffer, position)` and
-   `transferTo(WritableByteChannel, …)` (see `FileChannelRad`).
+   `transferTo(WritableByteChannel, …)` (see `FileChannelRad`). **Any override
+   that touches `access`/`access.api` for a releasable resource must call
+   `checkOpen()` first** (read-after-close UAF/leak), unless the handle itself
+   self-throws once closed (channels/`RandomAccessFile`). The cross-impl
+   `readingClosedHolderThrowsNotCrashes` exercises these four entry points, so a
+   missing guard reds CI.
 3. Public factory in `FooRadAccessor.kt` with
    `@file:JvmName("Rad") @file:JvmMultifileClass` and `@JvmName("forFoo")`
    per overload. Mark `@Blocking` if the constructor opens resources.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,15 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `subsection()` calls `retain()` on the underlying
   `SharedDataAccessor`; closing decrements; resource frees on the last
   close. **Each subsection MUST be closed independently** — otherwise the
-  underlying handle leaks.
+  underlying handle leaks. Conversely, **`close()` is idempotent per holder**
+  (`AccessorAwareRad` has a private atomicfu `closed` guard, `final` override):
+  a holder owns exactly one retain, so it must release at most once. Without the
+  guard a `Closeable`-legal double-close (`use{}` + manual, defensive close)
+  would decrement the *shared* refcount twice and prematurely free the resource
+  still used by the parent/siblings — `IOException` for file impls, a **JVM
+  `SIGABRT` use-after-free** for direct/mmap `ByteBuffer`. Regression:
+  `AbstractRandomAccessDataTest.doubleClosingSubsectionKeepsSharedResourceForParent`
+  runs across every impl, so a new RAD that drops the guard can't pass CI.
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,7 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `ANDROID_SDK_ROOT` / `ANDROID_HOME` so non-Android source sets can
   `compileOnly` the SDK jar.
 - `gradle/libs.versions.toml` — version+toolchain SoT; per-pin rationale
-  lives in catalog comments (minSdk floor is pinned to the modern
-  Android/Kotlin toolchain baseline, NOT to `AutoCloseable`'s API 19 floor).
+  lives in catalog comments.
 - `config/{detekt.yml,lint.xml}`; `.editorconfig` (ktlint_official,
   line=100, indent=4 for `.kt`/`.kts`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   aggregation, resolves `extra["androidJar"]` from `local.properties` /
   `ANDROID_SDK_ROOT` / `ANDROID_HOME` so non-Android source sets can
   `compileOnly` the SDK jar.
-- `gradle/libs.versions.toml` — single source of truth for versions and
-  toolchain (Kotlin lang/JVM target, AGP, minSdk because `AutoCloseable`
-  requires API 19).
+- `gradle/libs.versions.toml` — version+toolchain SoT; per-pin rationale
+  lives in catalog comments (minSdk floor is pinned to the modern
+  Android/Kotlin toolchain baseline, NOT to `AutoCloseable`'s API 19 floor).
 - `config/{detekt.yml,lint.xml}`; `.editorconfig` (ktlint_official,
   line=100, indent=4 for `.kt`/`.kts`).
 

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/AccessorAwareRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/AccessorAwareRad.kt
@@ -8,6 +8,7 @@ import fluxo.io.util.calcLength
 import fluxo.io.util.checkOffsetAndCount
 import fluxo.io.util.checkPositionAndMaxLength
 import kotlin.math.min
+import kotlinx.atomicfu.atomic
 
 @ThreadSafe
 internal abstract class AccessorAwareRad<A : SharedDataAccessor>
@@ -76,7 +77,22 @@ internal constructor(
     }
 
 
-    override fun close() {
-        access.close()
+    /**
+     * Guards [close] for one-shot release. Each holder — the root or any [subsection] —
+     * owns exactly one retain on the shared [access], so it must release at most once.
+     */
+    private val closed = atomic(false)
+
+    /**
+     * Idempotent, per the [java.io.Closeable] contract ("if already closed, invoking this
+     * method has no effect"). A repeated close must NOT decrement the shared refcount again:
+     * doing so would prematurely free the resource still in use by the parent or sibling
+     * subsections — for a memory-mapped buffer that is a use-after-free that crashes the JVM,
+     * not merely an [IOException]. Final so no subclass can reintroduce the unguarded path.
+     */
+    final override fun close() {
+        if (closed.compareAndSet(expect = false, update = true)) {
+            access.close()
+        }
     }
 }

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/SharedDataAccessorJvm.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/internal/SharedDataAccessorJvm.kt
@@ -1,0 +1,23 @@
+package fluxo.io.internal
+
+import fluxo.io.IOException
+
+/**
+ * Rejects access once the shared resource has been released ([SharedCloseable.isOpen] turns
+ * `false` from [SharedDataAccessor.onSharedClose] onward). JVM accessors that touch the resource
+ * directly must call this so a read after the last close fails with a clean [IOException] rather
+ * than hitting freed state — for a memory-mapped buffer that is a use-after-free that crashes the
+ * JVM, and for the stream pool it would silently leak a re-created stream into an already-drained
+ * pool. Channel-backed accessors need not call it: the JDK channel already throws
+ * `ClosedChannelException` once closed.
+ *
+ * JVM-only by construction: only the resource-backed JVM impls reach freed state, and only here
+ * can a descriptive [IOException] be raised (the common `expect class IOException` has no
+ * message constructor).
+ */
+@Throws(IOException::class)
+internal fun SharedDataAccessor.checkOpen() {
+    if (!isOpen) {
+        throw IOException("RandomAccessData is already closed")
+    }
+}

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/ByteBufferRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/ByteBufferRad.kt
@@ -3,6 +3,7 @@ package fluxo.io.rad
 import fluxo.io.IOException
 import fluxo.io.internal.AccessorAwareRad
 import fluxo.io.internal.SharedDataAccessor
+import fluxo.io.internal.checkOpen
 import fluxo.io.nio.limitCompat
 import fluxo.io.nio.positionCompat
 import fluxo.io.nio.releaseCompat
@@ -49,7 +50,7 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
 
 
     override fun readByteAt0(position: Long): Int =
-        access.api.get(toAccessPos(position)).toInt() and MAX_BYTE
+        access.readByteAt(toAccessPos(position))
 
     @Throws(IOException::class)
     override fun read(buffer: ByteBuffer, position: Long): Int {
@@ -90,10 +91,16 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
 
         override val size: Long get() = api.capacity().toLong()
 
+        fun readByteAt(position: Int): Int = synchronized(api) {
+            checkOpen()
+            api.get(position).toInt() and MAX_BYTE
+        }
+
         @Throws(IndexOutOfBoundsException::class)
         override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int {
             val buf = api
             synchronized(buf) {
+                checkOpen()
                 buf.limitCompat(buf.capacity())
                 buf.positionCompat(position.toInt())
                 val len = min(buf.remaining(), length)
@@ -107,6 +114,7 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
             val pos = position.toInt()
             val buf = api
             synchronized(buf) {
+                checkOpen()
                 val capacity = buf.capacity()
                 var len = capacity - pos
                 buf.limitCompat(pos + len)
@@ -129,6 +137,7 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
                 return 0
             }
             synchronized(buf) {
+                checkOpen()
                 buf.limitCompat(position + len)
                 buf.positionCompat(position)
                 var written = 0
@@ -140,7 +149,9 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
         }
 
         override fun onSharedClose() {
-            api.releaseCompat()
+            // Serialise the unmap with reads on the same monitor so an in-flight read can never
+            // observe a half-freed buffer; see [checkOpen]. [isOpen] is already false here.
+            synchronized(api) { api.releaseCompat() }
             super.onSharedClose()
         }
     }

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
@@ -5,6 +5,7 @@ import fluxo.io.EOFException
 import fluxo.io.IOException
 import fluxo.io.internal.AccessorAwareRad
 import fluxo.io.internal.SharedDataAccessor
+import fluxo.io.internal.checkOpen
 import fluxo.io.rad.StreamFactoryRad.StreamFactory
 import fluxo.io.rad.StreamFactoryRad.StreamFactoryAccess
 import fluxo.io.util.EMPTY_AUTO_CLOSEABLE_ARRAY
@@ -62,6 +63,7 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
         override val size: Long get() = factory.size
 
         override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int {
+            checkOpen()
             // Try to find a suitable stream in the pool or open new.
             // Use TreeMap thread safely.
             val pool = pool
@@ -90,6 +92,11 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
                     val newPosition = position + read
                     if (newPosition < srcLen) {
                         synchronized(pool) {
+                            // Recheck under the pool lock: if closed concurrently, onSharedClose
+                            // already drained the pool, so a put here would leak this stream
+                            // (never drained again). `isOpen` flips false before onSharedClose
+                            // runs, and the drain also holds this lock, so the check is exact.
+                            if (!isOpen) return@synchronized
                             val prev = pool.put(newPosition, stream)
                             closeStream = false
 

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
@@ -63,15 +63,12 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
         override val size: Long get() = factory.size
 
         override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int {
-            // Two-phase to keep concurrent close non-blocking even under a slow/hostile
-            // user `factory()`. Phase 1 (under pool monitor — the lock `onSharedClose`
-            // drains under): `checkOpen` + pool lookup, atomic. Phase 2 (no lock): open
-            // a fresh stream on miss. Phase 3 (under pool monitor): recheck `isOpen` —
-            // if `close` raced ahead, defensively close the fresh stream and reject.
-            // Without phase 3 a fresh stream against an officially-closed holder could
-            // return data (contract violation); with `factory` inside phase 1 a hostile
-            // factory would park `close` on the monitor (DoS) — the recheck is what
-            // restores both invariants.
+            // Three-phase, so a slow/hostile user `factory()` can't park concurrent `close`:
+            // (1) under pool monitor (same lock `onSharedClose` drains under) — `checkOpen`
+            // + pool lookup. (2) no lock — open fresh on miss. (3) under pool monitor —
+            // recheck `isOpen`; if `close` raced ahead, defensively close the fresh stream
+            // and reject. Holding `factory` under the monitor (the prior shape) DoS'd close;
+            // skipping (3) lets a fresh stream return data after the holder is closed.
             val pool = pool
             var streamOffset = 0L
             var stream: PooledStream<*>? = synchronized(pool) {

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
@@ -63,19 +63,25 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
         override val size: Long get() = factory.size
 
         override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int {
-            checkOpen()
-            // Try to find a suitable stream in the pool or open new.
-            // Use TreeMap thread safely.
+            // `checkOpen` + `factory()` MUST be under the pool monitor, the same lock
+            // `onSharedClose` drains under. Else a concurrent close after a release-time
+            // `checkOpen` could drain the empty pool, then this read would open a fresh
+            // stream against the (now-closed) source and return data — a contract
+            // violation. Holding the lock through `factory` is bounded (open is fast)
+            // and serialises with the one-shot drain. `stream.read` stays outside.
             val pool = pool
             var streamOffset = 0L
             val stream = synchronized(pool) b@{
+                checkOpen()
                 val entry = pool.floorEntry(position)
-                    ?: return@b null
-                val key = entry.key
-                streamOffset = key!!
-                pool.remove(key)
-                entry.value
-            } ?: factory()
+                if (entry != null) {
+                    val key = entry.key!!
+                    streamOffset = key
+                    pool.remove(key)
+                    return@b entry.value
+                }
+                factory()
+            }
 
             val read: Int
             var closeStream = true

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
@@ -63,24 +63,34 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
         override val size: Long get() = factory.size
 
         override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int {
-            // `checkOpen` + `factory()` MUST be under the pool monitor, the same lock
-            // `onSharedClose` drains under. Else a concurrent close after a release-time
-            // `checkOpen` could drain the empty pool, then this read would open a fresh
-            // stream against the (now-closed) source and return data — a contract
-            // violation. Holding the lock through `factory` is bounded (open is fast)
-            // and serialises with the one-shot drain. `stream.read` stays outside.
+            // Two-phase to keep concurrent close non-blocking even under a slow/hostile
+            // user `factory()`. Phase 1 (under pool monitor — the lock `onSharedClose`
+            // drains under): `checkOpen` + pool lookup, atomic. Phase 2 (no lock): open
+            // a fresh stream on miss. Phase 3 (under pool monitor): recheck `isOpen` —
+            // if `close` raced ahead, defensively close the fresh stream and reject.
+            // Without phase 3 a fresh stream against an officially-closed holder could
+            // return data (contract violation); with `factory` inside phase 1 a hostile
+            // factory would park `close` on the monitor (DoS) — the recheck is what
+            // restores both invariants.
             val pool = pool
             var streamOffset = 0L
-            val stream = synchronized(pool) b@{
+            var stream: PooledStream<*>? = synchronized(pool) {
                 checkOpen()
-                val entry = pool.floorEntry(position)
-                if (entry != null) {
-                    val key = entry.key!!
-                    streamOffset = key
-                    pool.remove(key)
-                    return@b entry.value
+                val entry = pool.floorEntry(position) ?: return@synchronized null
+                val key = entry.key!!
+                streamOffset = key
+                pool.remove(key)
+                entry.value
+            }
+            if (stream == null) {
+                val fresh = factory()
+                try {
+                    synchronized(pool) { checkOpen() }
+                } catch (e: Throwable) {
+                    runCatching { fresh.close() }.exceptionOrNull()?.let(e::addSuppressed)
+                    throw e
                 }
-                factory()
+                stream = fresh
             }
 
             val read: Int

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/SharedCloseableTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/SharedCloseableTest.kt
@@ -40,6 +40,26 @@ internal class SharedCloseableTest {
         assertEquals(1, closeable.closeCount)
     }
 
+    /**
+     * The read-after-close guard ([fluxo.io.internal.SharedDataAccessor]'s `checkOpen`) is only
+     * sound if `isOpen` is already `false` when the resource is released: a concurrent reader that
+     * serialises on the resource monitor must observe the closed state, not race a half-freed
+     * resource. Lock that ordering deterministically — `releaseRetain()` must leave the `Open`
+     * state before `onSharedClose()` runs. A refactor that freed resources before flipping state
+     * would turn this red, flagging the guard as unsound before it can crash the JVM.
+     */
+    @Test
+    fun resourceReleaseObservesClosedState() {
+        lateinit var closeable: TestCloseable
+        val openDuringClose = AtomicReference<Boolean>()
+        closeable = TestCloseable { openDuringClose.set(closeable.isOpen) }
+
+        closeable.close()
+
+        assertEquals(false, openDuringClose.get()) // null would mean onSharedClose never ran
+        assertEquals(1, closeable.closeCount)
+    }
+
     @Test
     fun onSharedCloseFailureAfterRetainIsReportedToListenersAndRethrown() {
         val closeFailure = IOException("close")

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
@@ -17,6 +17,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.nio.ByteBuffer
+import java.nio.channels.Channels
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicBoolean
@@ -270,6 +271,32 @@ internal abstract class AbstractRandomAccessDataTest(
         // The parent shares the same accessor and was never closed: it must stay usable.
         assertEquals(1, rad.readByteAt(1))
         assertEquals(BYTES, rad.readAllBytes())
+    }
+
+    /**
+     * Reading a resource-backed holder after it has been closed must fail cleanly with
+     * [IOException], never return stale bytes and never touch a freed resource. For a
+     * memory-mapped/direct `ByteBuffer` the freed region is unmapped, so an unguarded read is a
+     * native use-after-free that crashes the JVM; a stream pool would leak a re-created stream.
+     *
+     * Exercises every resource-touching entry point, because each may have a per-impl perf
+     * override that bypasses the shared `read(bytes)` primitive: `readByteAt`/`readFrom` plus
+     * `read(ByteBuffer)` and `transferTo`. Dropping the guard from any one override must turn
+     * this red — otherwise the gate covers only some paths and a UAF leaks through the rest.
+     *
+     * [RandomAccessDataArrayTest] overrides this: a `ByteArray` holds no releasable resource, so
+     * its `close()` is a no-op and reads stay valid — there is nothing to make unsafe.
+     */
+    @Test
+    open fun readingClosedHolderThrowsNotCrashes() = runTest(timeout = DEFAULT_TIMEOUT) {
+        inputStream.close()
+        rad.close() // root was the only holder, so the shared resource is now freed
+
+        val sink = Channels.newChannel(ByteArrayOutputStream())
+        assertFailsWith<IOException> { rad.readByteAt(0) }
+        assertFailsWith<IOException> { rad.readFrom(0, 1) }
+        assertFailsWith<IOException> { rad.read(ByteBuffer.allocate(1), 0) }
+        assertFailsWith<IOException> { rad.transferTo(sink) }
     }
 
     @Test

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
@@ -251,6 +251,27 @@ internal abstract class AbstractRandomAccessDataTest(
         subsection.close()
     }
 
+    /**
+     * Closing one holder more than once must be a no-op, per the [java.io.Closeable]
+     * contract ("if the stream is already closed then invoking this method has no
+     * effect"). A second close must NOT decrement the shared refcount again, else it
+     * prematurely frees the underlying resource still in use by the parent (and any
+     * sibling subsections), corrupting their reads.
+     */
+    @Test
+    fun doubleClosingSubsectionKeepsSharedResourceForParent() = runTest(timeout = DEFAULT_TIMEOUT) {
+        val subsection = rad.subsection(1, 1)
+        // Drop the stream's hold so only {rad, subsection} retain the shared accessor.
+        inputStream.close()
+
+        subsection.close()
+        subsection.close()
+
+        // The parent shares the same accessor and was never closed: it must stay usable.
+        assertEquals(1, rad.readByteAt(1))
+        assertEquals(BYTES, rad.readAllBytes())
+    }
+
     @Test
     fun inputStreamReadPastSubsection() = runTest(timeout = DEFAULT_TIMEOUT) {
         val subsection = rad.subsection(1, 2)

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/AbstractRandomAccessDataTest.kt
@@ -274,6 +274,21 @@ internal abstract class AbstractRandomAccessDataTest(
     }
 
     /**
+     * Closing a subsection while its parent is still open MUST leave reads on the (now-closed)
+     * subsection valid: the read-after-close guard rejects access only when the *shared*
+     * resource has been freed, not per-holder. Pins the by-design behaviour AGENTS.md
+     * documents — a renamed/removed guard that began rejecting per-holder would red this.
+     */
+    @Test
+    fun closingSubsectionLeavesItReadableWhileParentOpen() = runTest(timeout = DEFAULT_TIMEOUT) {
+        val subsection = rad.subsection(1, 2)
+        subsection.close()
+        // Shared resource still alive (root + inputStream retain): subsection reads succeed.
+        assertEquals(1, subsection.readByteAt(0)) // global offset 1, BYTES[1]=1
+        assertEquals(2, subsection.readByteAt(1)) // global offset 2, BYTES[2]=2
+    }
+
+    /**
      * Reading a resource-backed holder after it has been closed must fail cleanly with
      * [IOException], never return stale bytes and never touch a freed resource. For a
      * memory-mapped/direct `ByteBuffer` the freed region is unmapped, so an unguarded read is a

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
@@ -1,0 +1,142 @@
+package fluxo.io.rad
+
+import fluxo.io.nio.positionCompat
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.channels.WritableByteChannel
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Deterministic reproducers for the *concurrent* close-during-read hazards (the sequential case
+ * is covered by [AbstractRandomAccessDataTest.readingClosedHolderThrowsNotCrashes]). Both drive a
+ * real read past its open-check, freeze it mid-flight on a latch, run a full [close] from another
+ * thread, then resume — exercising the exact window the guards protect. No mocks: a real
+ * [InputStream]/[WritableByteChannel] whose blocking point is latch-coordinated.
+ */
+internal class RadConcurrentCloseTest {
+
+    private companion object {
+        private val DATA = ByteArray(64) { it.toByte() }
+        // < DATA.size, so the read leaves data and the stream is re-pooled (not closed at EOF)
+        private const val PARTIAL = 32
+        private const val TIMEOUT_S = 2L
+    }
+
+    /**
+     * A stream re-pooled by a read that was in flight while the resource closed must NOT leak:
+     * `onSharedClose` drains the pool exactly once, so a put after the drain is never closed.
+     * The fix rechecks `isOpen` under the pool lock and lets the `finally` close the stream.
+     * Without it, `opened > closed` (RED).
+     */
+    @Test
+    fun streamRePooledDuringConcurrentCloseIsNotLeaked() {
+        val opened = AtomicInteger()
+        val closed = AtomicInteger()
+        val readEntered = CountDownLatch(1)
+        val proceed = CountDownLatch(1)
+        val readerError = AtomicReference<Throwable?>()
+
+        val rad = StreamFactoryRadAccessor(DATA.size.toLong()) {
+            opened.incrementAndGet()
+            object : InputStream() {
+                private val src = ByteArrayInputStream(DATA)
+                override fun read(): Int = src.read()
+                override fun read(b: ByteArray, off: Int, len: Int): Int {
+                    readEntered.countDown()
+                    proceed.await()
+                    return src.read(b, off, len)
+                }
+                override fun close() {
+                    closed.incrementAndGet()
+                    src.close()
+                }
+            }
+        }
+
+        val reader = thread {
+            try {
+                rad.readFrom(0, PARTIAL)
+            } catch (e: Throwable) {
+                readerError.set(e)
+            }
+        }
+
+        assertTrue(readEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "read never entered")
+        rad.close() // drains the empty pool (stream is checked out); resource now freed
+        proceed.countDown() // in-flight read resumes and attempts to re-pool its stream
+        reader.join(TIMEOUT_S * 1000)
+
+        assertFalse(reader.isAlive, "reader did not finish")
+        assertNull(readerError.get())
+        assertTrue(opened.get() >= 1, "no stream was opened")
+        assertEquals(opened.get(), closed.get(), "a re-pooled stream leaked after concurrent close")
+    }
+
+    /**
+     * The mmap/direct unmap in `onSharedClose` must not run while a read holds the resource
+     * monitor, else it frees the buffer under an in-flight `get`/`put` (native use-after-free).
+     * Proven on a heap buffer (no crash risk): the unmap is `synchronized(api)`, so a concurrent
+     * `close` blocks on the monitor the in-flight `transferTo` holds. Without that synchronisation
+     * `close` completes mid-read (RED) — caught here before it can ever crash on a real mmap.
+     */
+    @Test
+    fun unmapWaitsForInFlightRead() {
+        val rad = RadByteBufferAccessor(DATA)
+        val writeEntered = CountDownLatch(1)
+        val proceed = CountDownLatch(1)
+        val transferError = AtomicReference<Throwable?>()
+
+        val channel = object : WritableByteChannel {
+            override fun write(src: ByteBuffer): Int {
+                writeEntered.countDown()
+                proceed.await()
+                val n = src.remaining()
+                src.positionCompat(src.limit())
+                return n
+            }
+            override fun isOpen() = true
+            override fun close() = Unit
+        }
+
+        val transfer = thread {
+            try {
+                rad.transferTo(channel)
+            } catch (e: Throwable) {
+                transferError.set(e)
+            }
+        }
+        assertTrue(writeEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "transfer never entered")
+
+        val closeDone = AtomicBoolean(false)
+        val closer = thread {
+            rad.close()
+            closeDone.set(true)
+        }
+
+        // The closer must park on the resource monitor until the in-flight transfer releases it.
+        val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
+        while (closer.state != Thread.State.BLOCKED) {
+            assertFalse(closeDone.get(), "close finished mid-read — unmap not serialised")
+            if (System.nanoTime() > deadline) fail("closer never blocked on the resource monitor")
+            Thread.onSpinWait()
+        }
+
+        proceed.countDown()
+        transfer.join(TIMEOUT_S * 1000)
+        closer.join(TIMEOUT_S * 1000)
+        assertNull(transferError.get())
+        assertTrue(closeDone.get(), "close did not complete after the read released the monitor")
+    }
+}

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
@@ -129,18 +129,23 @@ internal class RadConcurrentCloseTest {
                 readerError.set(e)
             }
         }
+        // Closer started only after the reader is parked INSIDE factory — else a scheduler
+        // that runs closer first (observed on Windows CI under load) drains the empty pool,
+        // and reader's phase-1 `checkOpen` rejects before factory is ever entered. That race
+        // would shadow the actual invariant being tested with a misleading "factory never
+        // entered" failure.
+        assertTrue(factoryEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "factory never entered")
         val closeDone = AtomicBoolean(false)
         val closer = thread {
             rad.close()
             closeDone.set(true)
         }
         try {
-            assertTrue(factoryEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "factory never entered")
-            // The closer ran while the reader paused inside factory. The proper fix opens
-            // factory OUTSIDE the pool monitor, so close drains the empty pool and returns
-            // promptly — `closeDone` flips well within `quickJoinMs`. The prior band-aid
-            // (`factory` under the pool monitor) parks close behind reader's await; closer
-            // would stay alive past the deadline → RED with a clear assertion, no hang.
+            // Proper fix opens factory OUTSIDE the pool monitor, so close drains the empty
+            // pool and returns promptly — `closeDone` flips well within `quickJoinMs`. The
+            // prior band-aid (`factory` under the pool monitor) parked close behind reader's
+            // await; closer would stay alive past the deadline → RED with a clear assertion,
+            // no hang.
             val quickJoinMs = TIMEOUT_S * 1000 / 4
             closer.join(quickJoinMs)
             assertTrue(closeDone.get(), "close parked on factory (DoS-on-close band-aid)")

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
@@ -190,18 +190,16 @@ internal class RadConcurrentCloseTest {
                 transferError.set(e)
             }
         }
+        // Closer is started only after the transfer is in the resource monitor —
+        // otherwise close could win the monitor, unmap, and the transfer's checkOpen
+        // would throw instead of demonstrating the in-flight-blocks-close invariant.
+        assertTrue(writeEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "transfer never entered")
         val closeDone = AtomicBoolean(false)
-        var closer: Thread? = null
+        val closer = thread {
+            rad.close()
+            closeDone.set(true)
+        }
         try {
-            // The closer is started only after the transfer is in the resource monitor —
-            // otherwise close could win the monitor, unmap, and the transfer's checkOpen
-            // would throw instead of demonstrating the in-flight-blocks-close invariant.
-            assertTrue(writeEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "transfer never entered")
-            closer = thread {
-                rad.close()
-                closeDone.set(true)
-            }
-
             // The closer must park on the resource monitor until the in-flight transfer releases.
             val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
             while (closer.state != Thread.State.BLOCKED) {
@@ -211,11 +209,11 @@ internal class RadConcurrentCloseTest {
             }
         } finally {
             // Always release the transfer so a failed assertion doesn't strand it blocked
-            // on `proceed.await()`; the closer (if started) is no longer parked behind it either.
+            // on `proceed.await()`; the closer is no longer parked behind it either.
             proceed.countDown()
         }
         transfer.join(TIMEOUT_S * 1000)
-        closer?.join(TIMEOUT_S * 1000)
+        closer.join(TIMEOUT_S * 1000)
         assertNull(transferError.get())
         assertTrue(closeDone.get(), "close did not complete after the read released the monitor")
     }

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
@@ -1,5 +1,6 @@
 package fluxo.io.rad
 
+import fluxo.io.IOException
 import fluxo.io.nio.positionCompat
 import java.io.ByteArrayInputStream
 import java.io.InputStream
@@ -90,16 +91,18 @@ internal class RadConcurrentCloseTest {
     }
 
     /**
-     * A read that opens a fresh stream (pool miss) MUST hold the pool monitor through the
-     * factory call, else a concurrent close can drain the (already-empty) pool and return
-     * *before* the factory opens its stream — a ghost read against an officially-closed
-     * holder. Without the under-lock guard the closer is uncontested (reader pauses inside
-     * factory holding no lock), reaches `RUNNABLE→TERMINATED` instead of `BLOCKED`, and
-     * `closeDone` flips while the loop still spins — RED. The fix keeps `factory` inside
-     * `synchronized(pool)` so the closer's drain parks behind it.
+     * Concurrent `close` while a read is mid-`factory()` must (a) NOT park on the pool
+     * monitor — a slow/hostile user factory cannot DoS close or sibling readers; (b) cause
+     * the racing read to reject with [IOException] on the post-`factory` `isOpen` recheck;
+     * (c) defensively close the freshly-opened stream so it is not leaked into a drained
+     * pool. RED on the prior "hold `factory` under the pool monitor" band-aid (close would
+     * BLOCK and `closeDone` would never flip while factory paused). RED on a fix that
+     * rejects the read but forgets to close the orphan stream (`opened != closed`).
      */
     @Test
-    fun closeBlocksWhileReadOpensFreshStream() {
+    fun concurrentCloseDoesNotBlockOnFactoryAndOrphanStreamIsClosed() {
+        val opened = AtomicInteger()
+        val closed = AtomicInteger()
         val factoryEntered = CountDownLatch(1)
         val proceedFactory = CountDownLatch(1)
         val readerError = AtomicReference<Throwable?>()
@@ -107,11 +110,15 @@ internal class RadConcurrentCloseTest {
         val rad = StreamFactoryRadAccessor(DATA.size.toLong()) {
             factoryEntered.countDown()
             proceedFactory.await()
+            opened.incrementAndGet()
             object : InputStream() {
                 private val src = ByteArrayInputStream(DATA)
                 override fun read(): Int = src.read()
                 override fun read(b: ByteArray, off: Int, len: Int): Int = src.read(b, off, len)
-                override fun close() = src.close()
+                override fun close() {
+                    closed.incrementAndGet()
+                    src.close()
+                }
             }
         }
 
@@ -123,29 +130,31 @@ internal class RadConcurrentCloseTest {
             }
         }
         val closeDone = AtomicBoolean(false)
-        var closer: Thread? = null
+        val closer = thread {
+            rad.close()
+            closeDone.set(true)
+        }
         try {
             assertTrue(factoryEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "factory never entered")
-            closer = thread {
-                rad.close()
-                closeDone.set(true)
-            }
-            // The closer must park on the pool monitor while the reader is inside `factory`
-            // (i.e. holding `synchronized(pool)`). If it reaches TERMINATED before BLOCKED,
-            // the under-lock guard is missing — `closeDone` flips first and reds the loop.
-            val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
-            while (closer.state != Thread.State.BLOCKED) {
-                assertFalse(closeDone.get(), "close completed mid-factory — ghost-read race")
-                if (System.nanoTime() > deadline) fail("closer never blocked on the pool monitor")
-                Thread.onSpinWait()
-            }
+            // The closer ran while the reader paused inside factory. The proper fix opens
+            // factory OUTSIDE the pool monitor, so close drains the empty pool and returns
+            // promptly — `closeDone` flips well within `quickJoinMs`. The prior band-aid
+            // (`factory` under the pool monitor) parks close behind reader's await; closer
+            // would stay alive past the deadline → RED with a clear assertion, no hang.
+            val quickJoinMs = TIMEOUT_S * 1000 / 4
+            closer.join(quickJoinMs)
+            assertTrue(closeDone.get(), "close parked on factory (DoS-on-close band-aid)")
         } finally {
             proceedFactory.countDown()
         }
         reader.join(TIMEOUT_S * 1000)
-        closer?.join(TIMEOUT_S * 1000)
-        assertNull(readerError.get())
-        assertTrue(closeDone.get(), "close never completed after factory released the pool")
+        closer.join(TIMEOUT_S * 1000)
+
+        assertFalse(reader.isAlive, "reader did not finish")
+        val err = readerError.get()
+        assertTrue(err is IOException, "read should have rejected with IOException; was $err")
+        assertEquals(1, opened.get(), "factory ran exactly once")
+        assertEquals(1, closed.get(), "orphan stream was leaked after concurrent close")
     }
 
     /**

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RadConcurrentCloseTest.kt
@@ -73,15 +73,79 @@ internal class RadConcurrentCloseTest {
             }
         }
 
-        assertTrue(readEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "read never entered")
-        rad.close() // drains the empty pool (stream is checked out); resource now freed
-        proceed.countDown() // in-flight read resumes and attempts to re-pool its stream
+        try {
+            assertTrue(readEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "read never entered")
+            rad.close() // drains the empty pool (stream is checked out); resource now freed
+        } finally {
+            // Always release the reader so a failed pre-close assertion doesn't strand the
+            // thread blocked on `proceed.await()` past the test method return.
+            proceed.countDown()
+        }
         reader.join(TIMEOUT_S * 1000)
 
         assertFalse(reader.isAlive, "reader did not finish")
         assertNull(readerError.get())
         assertTrue(opened.get() >= 1, "no stream was opened")
         assertEquals(opened.get(), closed.get(), "a re-pooled stream leaked after concurrent close")
+    }
+
+    /**
+     * A read that opens a fresh stream (pool miss) MUST hold the pool monitor through the
+     * factory call, else a concurrent close can drain the (already-empty) pool and return
+     * *before* the factory opens its stream — a ghost read against an officially-closed
+     * holder. Without the under-lock guard the closer is uncontested (reader pauses inside
+     * factory holding no lock), reaches `RUNNABLE→TERMINATED` instead of `BLOCKED`, and
+     * `closeDone` flips while the loop still spins — RED. The fix keeps `factory` inside
+     * `synchronized(pool)` so the closer's drain parks behind it.
+     */
+    @Test
+    fun closeBlocksWhileReadOpensFreshStream() {
+        val factoryEntered = CountDownLatch(1)
+        val proceedFactory = CountDownLatch(1)
+        val readerError = AtomicReference<Throwable?>()
+
+        val rad = StreamFactoryRadAccessor(DATA.size.toLong()) {
+            factoryEntered.countDown()
+            proceedFactory.await()
+            object : InputStream() {
+                private val src = ByteArrayInputStream(DATA)
+                override fun read(): Int = src.read()
+                override fun read(b: ByteArray, off: Int, len: Int): Int = src.read(b, off, len)
+                override fun close() = src.close()
+            }
+        }
+
+        val reader = thread {
+            try {
+                rad.readFrom(0, PARTIAL)
+            } catch (e: Throwable) {
+                readerError.set(e)
+            }
+        }
+        val closeDone = AtomicBoolean(false)
+        var closer: Thread? = null
+        try {
+            assertTrue(factoryEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "factory never entered")
+            closer = thread {
+                rad.close()
+                closeDone.set(true)
+            }
+            // The closer must park on the pool monitor while the reader is inside `factory`
+            // (i.e. holding `synchronized(pool)`). If it reaches TERMINATED before BLOCKED,
+            // the under-lock guard is missing — `closeDone` flips first and reds the loop.
+            val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
+            while (closer.state != Thread.State.BLOCKED) {
+                assertFalse(closeDone.get(), "close completed mid-factory — ghost-read race")
+                if (System.nanoTime() > deadline) fail("closer never blocked on the pool monitor")
+                Thread.onSpinWait()
+            }
+        } finally {
+            proceedFactory.countDown()
+        }
+        reader.join(TIMEOUT_S * 1000)
+        closer?.join(TIMEOUT_S * 1000)
+        assertNull(readerError.get())
+        assertTrue(closeDone.get(), "close never completed after factory released the pool")
     }
 
     /**
@@ -117,25 +181,32 @@ internal class RadConcurrentCloseTest {
                 transferError.set(e)
             }
         }
-        assertTrue(writeEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "transfer never entered")
-
         val closeDone = AtomicBoolean(false)
-        val closer = thread {
-            rad.close()
-            closeDone.set(true)
-        }
+        var closer: Thread? = null
+        try {
+            // The closer is started only after the transfer is in the resource monitor —
+            // otherwise close could win the monitor, unmap, and the transfer's checkOpen
+            // would throw instead of demonstrating the in-flight-blocks-close invariant.
+            assertTrue(writeEntered.await(TIMEOUT_S, TimeUnit.SECONDS), "transfer never entered")
+            closer = thread {
+                rad.close()
+                closeDone.set(true)
+            }
 
-        // The closer must park on the resource monitor until the in-flight transfer releases it.
-        val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
-        while (closer.state != Thread.State.BLOCKED) {
-            assertFalse(closeDone.get(), "close finished mid-read — unmap not serialised")
-            if (System.nanoTime() > deadline) fail("closer never blocked on the resource monitor")
-            Thread.onSpinWait()
+            // The closer must park on the resource monitor until the in-flight transfer releases.
+            val deadline = System.nanoTime() + TIMEOUT_S * 1_000_000_000L
+            while (closer.state != Thread.State.BLOCKED) {
+                assertFalse(closeDone.get(), "close finished mid-read — unmap not serialised")
+                if (System.nanoTime() > deadline) fail("closer never blocked on resource monitor")
+                Thread.onSpinWait()
+            }
+        } finally {
+            // Always release the transfer so a failed assertion doesn't strand it blocked
+            // on `proceed.await()`; the closer (if started) is no longer parked behind it either.
+            proceed.countDown()
         }
-
-        proceed.countDown()
         transfer.join(TIMEOUT_S * 1000)
-        closer.join(TIMEOUT_S * 1000)
+        closer?.join(TIMEOUT_S * 1000)
         assertNull(transferError.get())
         assertTrue(closeDone.get(), "close did not complete after the read released the monitor")
     }

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RandomAccessDataArrayTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RandomAccessDataArrayTest.kt
@@ -1,7 +1,11 @@
 package fluxo.io.rad
 
 import fluxo.io.util.EMPTY_BYTE_ARRAY
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /**
  * Tests for [RadByteArrayAccessor].
@@ -9,6 +13,23 @@ import kotlin.test.Test
 internal class RandomAccessDataArrayTest : AbstractRandomAccessDataTest(
     { RadByteArrayAccessor(BYTES) }
 ) {
+    /**
+     * A [ByteArray] holds no releasable resource, so [ByteArrayRad.close] is a no-op and reads
+     * stay valid afterwards — there is no freed state to make a use-after-close unsafe, and
+     * guarding the fastest impl's hot path would buy no safety. The reject-after-close contract
+     * applies only to resource-backed impls.
+     */
+    @Test
+    override fun readingClosedHolderThrowsNotCrashes() {
+        inputStream.close()
+        rad.close()
+        val sink = Channels.newChannel(ByteArrayOutputStream())
+        assertEquals(0, rad.readByteAt(0))
+        assertEquals(byteArrayOf(0), rad.readFrom(0, 1))
+        assertEquals(1, rad.read(ByteBuffer.allocate(1), 0))
+        assertEquals(BYTES.size.toLong(), rad.transferTo(sink))
+    }
+
     @Test
     fun creationBoundaries() {
         assertEmptyRad(RadByteArrayAccessor(EMPTY_BYTE_ARRAY))

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RandomAccessDataArrayTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/rad/RandomAccessDataArrayTest.kt
@@ -24,9 +24,15 @@ internal class RandomAccessDataArrayTest : AbstractRandomAccessDataTest(
         inputStream.close()
         rad.close()
         val sink = Channels.newChannel(ByteArrayOutputStream())
-        assertEquals(0, rad.readByteAt(0))
-        assertEquals(byteArrayOf(0), rad.readFrom(0, 1))
-        assertEquals(1, rad.read(ByteBuffer.allocate(1), 0))
+        // Assert at non-zero indices: BYTES[i]=i.toByte(), so a regression that
+        // cleared/zeroed the backing on close would still pass `==0` assertions by
+        // accident. Non-zero indices + content checks distinguish a real read from a
+        // zeroed read.
+        assertEquals(5, rad.readByteAt(5))
+        assertEquals(byteArrayOf(3, 4, 5), rad.readFrom(3, 3))
+        val buf = ByteBuffer.allocate(1)
+        assertEquals(1, rad.read(buf, 7))
+        assertEquals(7, buf.array()[0].toInt())
         assertEquals(BYTES.size.toLong(), rad.transferTo(sink))
     }
 


### PR DESCRIPTION
Stacked on #37 (base = `fix/rad-close-idempotency`); auto-retargets to `dev` when #37 lands.

## Problem
A read through a holder whose shared resource was already released (last close) hit freed state:
- direct/mmap `ByteBuffer` → native use-after-free / JVM **SIGABRT** (region unmapped by `releaseCompat()`);
- `StreamFactory` → re-pooled a re-created stream into an already-drained pool → silent **stream leak**.

The 4 file/channel impls self-throw `ClosedChannelException`/`IOException`, so the class is JVM- and impl-specific.

## Fix
Guard at the **resource-owner** layer (`SharedDataAccessor.checkOpen()`, `internal` extension in `commonJvmMain`) — `AccessorAwareRad`-level guards are bypassed by the perf overrides (`readByteAt0`, `read(ByteBuffer)`, `transferTo`) that touch the resource directly (that first attempt was falsified). Concurrent close-during-read is sound because `releaseRetain()` flips `isOpen` false **before** `onSharedClose()`, and reads share the resource monitor with the unmap (ByteBuffer `synchronized(api)`; StreamFactory `isOpen` recheck under the pool lock). `ByteArray` is exempt (no resource, hot path).

## Evidence (all RED-bisected vs real impls, no mocks)
- `readingClosedHolderThrowsNotCrashes` — every impl × all four read entry points; drop any one guard → red.
- `SharedCloseableTest.resourceReleaseObservesClosedState` — locks the isOpen-before-onSharedClose ordering.
- `RadConcurrentCloseTest` — latch-freezes a real in-flight read mid-close (deterministic, 12/12, no sleeps); reds without each concurrent guard.

Full reasoning in `AGENTS.md` + the commit body. `jvmTest` 1323+, KLIB/JVM BCV clean, detekt clean, `verifyBuildPolicy` pass.