### PR TITLE
fix(rad): structurally eliminate onSharedClose leak-on-throw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,10 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   parent is still open succeeds (by design).
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
-  `onSharedClose()` is **`final` template** — releasing the API-specific
-  resource (mmap unmap, drain pool) goes in a `protected open fun releaseApi()`
-  override; the template wraps it so a release-throw still closes the
-  `resources` AutoCloseable array (latest exception primary, prior suppressed).
-  Pinned by `SharedDataAccessorReleaseApiTest`. Direct `onSharedClose` overrides
-  are compile-blocked — bug class is structurally impossible.
+  `onSharedClose()` is `final`; release the API in `protected open fun releaseApi()`
+  — the template always closes the `resources` array even if release throws.
+  Direct `onSharedClose` overrides are compile-blocked (see
+  `SharedDataAccessorReleaseApiTest`).
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks
   (`fluxo.io.util.IoUtil`). `BasicRad` (expect/actual) carries the JVM
   common impl: `readByteAt`, `transferTo`, `read(ByteBuffer, position)`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   parent is still open succeeds (by design).
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
+  `onSharedClose()` is **`final` template** — releasing the API-specific
+  resource (mmap unmap, drain pool) goes in a `protected open fun releaseApi()`
+  override; the template wraps it so a release-throw still closes the
+  `resources` AutoCloseable array (latest exception primary, prior suppressed).
+  Pinned by `SharedDataAccessorReleaseApiTest`. Direct `onSharedClose` overrides
+  are compile-blocked — bug class is structurally impossible.
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks
   (`fluxo.io.util.IoUtil`). `BasicRad` (expect/actual) carries the JVM
   common impl: `readByteAt`, `transferTo`, `read(ByteBuffer, position)`,

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/ByteBufferRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/ByteBufferRad.kt
@@ -148,11 +148,10 @@ private constructor(access: ByteBufferAccess, offset: Int, size: Int) :
             return len.toLong()
         }
 
-        override fun onSharedClose() {
+        override fun releaseApi() {
             // Serialise the unmap with reads on the same monitor so an in-flight read can never
             // observe a half-freed buffer; see [checkOpen]. [isOpen] is already false here.
             synchronized(api) { api.releaseCompat() }
-            super.onSharedClose()
         }
     }
 }

--- a/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
+++ b/fluxo-io-rad/src/commonJvmMain/kotlin/fluxo/io/rad/StreamFactoryRad.kt
@@ -133,7 +133,7 @@ private constructor(access: StreamFactoryAccess, offset: Long, size: Long) :
             return read
         }
 
-        override fun onSharedClose() {
+        override fun releaseApi() {
             val pool = pool
             synchronized(pool) {
                 var t: Throwable? = null

--- a/fluxo-io-rad/src/commonMain/kotlin/fluxo/io/internal/SharedDataAccessor.kt
+++ b/fluxo-io-rad/src/commonMain/kotlin/fluxo/io/internal/SharedDataAccessor.kt
@@ -20,24 +20,16 @@ protected constructor(
     abstract fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int
 
     /**
-     * Release the API-specific resource (mmap unmap, drain pool, etc.). Default no-op.
-     * A throw here MUST NOT skip closing the [resources] array — the [onSharedClose]
-     * template enforces that via try-finally semantics, so impls that previously did
-     * `api.release(); super.onSharedClose()` and leaked on release-throw cannot be
-     * reintroduced. Caller is single-shot from [SharedCloseable.close]; need not
-     * be re-entrant or idempotent.
+     * Release the API-specific resource (mmap unmap, pool drain, …). May throw;
+     * the [onSharedClose] template still closes the [resources] array. Default no-op.
      */
     @Throws(IOException::class)
     protected open fun releaseApi() {}
 
     /**
-     * Final template: release the API (may throw), then ALWAYS close the [resources]
-     * array. If both phases throw, the resource-close exception becomes primary with
-     * the release exception attached as suppressed (matching the existing
-     * per-resource error-merge convention below).
-     *
-     * Note: Can be non-synchronized as guarded by [SharedCloseable]
-     * and normally by the object itself.
+     * Template: [releaseApi] then close [resources]; the latter always runs even
+     * if release throws. Errors merge per the existing convention (latest primary,
+     * earlier suppressed). Non-synchronized — guarded by [SharedCloseable].
      */
     final override fun onSharedClose() {
         var t: Throwable? = null

--- a/fluxo-io-rad/src/commonMain/kotlin/fluxo/io/internal/SharedDataAccessor.kt
+++ b/fluxo-io-rad/src/commonMain/kotlin/fluxo/io/internal/SharedDataAccessor.kt
@@ -20,13 +20,32 @@ protected constructor(
     abstract fun read(bytes: ByteArray, position: Long, offset: Int, length: Int): Int
 
     /**
+     * Release the API-specific resource (mmap unmap, drain pool, etc.). Default no-op.
+     * A throw here MUST NOT skip closing the [resources] array — the [onSharedClose]
+     * template enforces that via try-finally semantics, so impls that previously did
+     * `api.release(); super.onSharedClose()` and leaked on release-throw cannot be
+     * reintroduced. Caller is single-shot from [SharedCloseable.close]; need not
+     * be re-entrant or idempotent.
+     */
+    @Throws(IOException::class)
+    protected open fun releaseApi() {}
+
+    /**
+     * Final template: release the API (may throw), then ALWAYS close the [resources]
+     * array. If both phases throw, the resource-close exception becomes primary with
+     * the release exception attached as suppressed (matching the existing
+     * per-resource error-merge convention below).
      *
      * Note: Can be non-synchronized as guarded by [SharedCloseable]
      * and normally by the object itself.
      */
-    @CallSuper
-    override fun onSharedClose() {
+    final override fun onSharedClose() {
         var t: Throwable? = null
+        try {
+            releaseApi()
+        } catch (e: Throwable) {
+            t = e
+        }
         for (resource in resources) {
             try {
                 resource.close()

--- a/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/internal/SharedDataAccessorReleaseApiTest.kt
+++ b/fluxo-io-rad/src/jvmTest/kotlin/fluxo/io/internal/SharedDataAccessorReleaseApiTest.kt
@@ -1,0 +1,88 @@
+package fluxo.io.internal
+
+import fluxo.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Falsifies the structural fix for the `onSharedClose` leak-on-throw bug class:
+ * a release-throw MUST NOT skip the [SharedDataAccessor] `resources` close pass.
+ *
+ * RED-bisect: revert [SharedDataAccessor] to the pre-template form
+ * (`api.releaseCompat(); super.onSharedClose()` pattern with no try-finally)
+ * and these tests turn red; restore the final-template form to make them green.
+ */
+internal class SharedDataAccessorReleaseApiTest {
+
+    @Test
+    fun releaseApiThrowDoesNotLeakResources() {
+        val resource = TrackingCloseable()
+        val accessor = ThrowingReleaseAccessor(IOException("release boom"), resource)
+
+        val thrown = assertFailsWith<IOException> { accessor.close() }
+
+        assertEquals("release boom", thrown.message)
+        assertTrue(resource.closed.get(), "resources MUST close even when releaseApi throws")
+    }
+
+    @Test
+    fun releaseApiSuccessClosesResources() {
+        val a = TrackingCloseable()
+        val b = TrackingCloseable()
+        val accessor = OkReleaseAccessor(a, b)
+
+        accessor.close()
+
+        assertTrue(a.closed.get())
+        assertTrue(b.closed.get())
+        assertTrue(accessor.releaseCalled.get())
+    }
+
+    @Test
+    fun bothReleaseAndResourceThrowSurfaceWithSuppression() {
+        val releaseErr = IOException("release boom")
+        val resourceErr = IOException("resource boom")
+        val accessor = ThrowingReleaseAccessor(releaseErr, FailingCloseable(resourceErr))
+
+        val thrown = assertFailsWith<IOException> { accessor.close() }
+
+        // Convention (matches resource-merge logic): latest exception primary, earlier suppressed.
+        assertSame(resourceErr, thrown)
+        assertEquals(1, thrown.suppressed.size)
+        assertSame(releaseErr, thrown.suppressed[0])
+    }
+
+    private class TrackingCloseable : AutoCloseable {
+        val closed = AtomicBoolean(false)
+        override fun close() {
+            check(closed.compareAndSet(false, true)) { "double-closed" }
+        }
+    }
+
+    private class FailingCloseable(private val err: Throwable) : AutoCloseable {
+        override fun close(): Unit = throw err
+    }
+
+    private class OkReleaseAccessor(vararg resources: AutoCloseable) :
+        SharedDataAccessor(resources) {
+        val releaseCalled = AtomicBoolean(false)
+        override val size: Long get() = 0L
+        override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int) = -1
+        override fun releaseApi() {
+            releaseCalled.set(true)
+        }
+    }
+
+    private class ThrowingReleaseAccessor(
+        private val err: Throwable,
+        vararg resources: AutoCloseable,
+    ) : SharedDataAccessor(resources) {
+        override val size: Long get() = 0L
+        override fun read(bytes: ByteArray, position: Long, offset: Int, length: Int) = -1
+        override fun releaseApi(): Unit = throw err
+    }
+}


### PR DESCRIPTION
## Summary

Structural defense-in-depth, not a field-bug. `AccessorAwareRad` subclasses
that override `onSharedClose` to release an API resource before calling
`super.onSharedClose()` silently skip the base's `resources`-close pass if
the release op throws.

`ByteBufferRad.api.releaseCompat()` is the only path that can plausibly
throw in practice — not from `Cleaner.clean()` itself, which `BufferUtil0`
swallows into `LOGGER?.invoke(...)`, but from a misbehaving user-supplied
logger (or a future JDK reflection regression that the swallow path
mishandles). Rare, but reachable; the on-leak vector is the mmap-backing
`FileChannel`.

Per-impl `try-finally` patches the two existing subclasses but lets the
bug class re-emerge in any future RAD impl.

## Fix

`SharedDataAccessor.onSharedClose` is now `final` and acts as a template:
release via a `protected open fun releaseApi()` slot wrapped in
`try-catch`, then always iterate `resources` and close each. Error-merge
matches the existing per-resource convention (latest primary, earlier
suppressed).

`ByteBufferRad` and `StreamFactoryRad` move their release ops onto the
slot — the other four impls inherit the no-op default. The buggy
`release(); super(...)` pattern is no longer typeable; the compiler
rejects future re-introductions.

Diff: +20 LOC prod, +90 LOC test, –4 LOC across the two refactored impls.

## Test plan

- [x] `SharedDataAccessorReleaseApiTest` — three RED-bisected cases against
  real `SharedDataAccessor` subclasses (no mocks). Flipping the template
  back to non-`try-finally` reds 2/3 cases (the happy path stays green —
  expected; the bug only triggers on throw).
- [x] `./gradlew check` green (JVM tests, JVM+KLIB+TS BCV, detekt, lint,
  depGuard, kover).
- [x] `./gradlew verifyBuildPolicy` green.

## Caveats

- Walked back from the original "real-world impact path" framing — the
  field-trigger path requires a misbehaving logger or JDK regression
  layered on top of a Cleaner reflection failure, so it is rare. The
  structural lock is the value, not a regression repro for a known
  in-the-wild bug.
- Stacks logically after #38 (the real safety fixes); will rebase once
  that lands.