### PR TITLE
chore(updateBaseline): drop dead detektBaselineMerge ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
 ./gradlew check                    # full verify (BCV apiCheck, kover, detekt, AGP lint wiring, depGuard, tests)
 ./gradlew :fluxo-io-rad:jvmTest    # JVM unit tests
 ./gradlew :fluxo-io-rad:apiDump    # refresh BCV after intentional API change
-./updateBaseline                   # CANONICAL regen: verification metadata+yarnLock+apiDump+depGuardBaseline+detektBaselineMerge (CI=true RELEASE=true, no build/config cache, isolated .gradle/update-baseline home unless GRADLE_USER_HOME is set)
+./updateBaseline                   # CANONICAL regen: verification metadata+yarnLock+apiDump+depGuardBaseline (CI=true RELEASE=true, no build/config cache, isolated .gradle/update-baseline home unless GRADLE_USER_HOME is set)
 ```
 - Configuration cache is on with `problems=fail` and `max-problems=0`.
   Don't capture `Project` or build-script instances in task actions.

--- a/updateBaseline
+++ b/updateBaseline
@@ -7,8 +7,11 @@ if [ -z "${GRADLE_USER_HOME}" ]; then
   export GRADLE_USER_HOME="${PWD}/.gradle/update-baseline"
 fi
 
-BASELINE_TASKS="apiDump dependencyGuardBaseline detektBaselineMerge"
-VERIFICATION_BASELINE_TASKS="dependencyGuardBaseline detektBaselineMerge"
+# `detektBaselineMerge` is intentionally NOT listed: no such task exists under the
+# current fluxo-kmp-conf / Detekt setup (only per-target `detektBaselineXxx`).
+# The repo does not adopt detekt baselines; if it does later, wire the merge here.
+BASELINE_TASKS="apiDump dependencyGuardBaseline"
+VERIFICATION_BASELINE_TASKS="dependencyGuardBaseline"
 COMMON_TASKS="${BASELINE_TASKS} --continue -Dlint.baselines.continue=true"
 GRADLE_BASE_ARGS="--no-daemon --no-configuration-cache"
 VERIFY_TASKS="help kotlinUpgradeYarnLock"


### PR DESCRIPTION
## Summary

`detektBaselineMerge` is referenced from `BASELINE_TASKS` and
`VERIFICATION_BASELINE_TASKS` but is not a Gradle task under the current
fluxo-kmp-conf / Detekt wiring — only per-target `detektBaseline*` tasks
exist (`detektBaselineJvm`, `detektBaselineAndroidMain`, …). The
script's `--continue` flag silently masked the missing-task failure on
every run, so the slot was a no-op.

The repo doesn't use Detekt baselines (no `config/detekt-baseline.xml`).
Drop the dead refs. Update AGENTS.md command annotation to match. Leave
a comment so a future agent doesn't re-add it.

## Test plan

- [x] No-op behaviour change — removing a never-executed task is exactly
  that.
- [x] Detekt itself still runs via `./gradlew detekt`/`check`.

Discovered during the A2 (`fix(rad): structurally eliminate
onSharedClose leak-on-throw`) audit when `updateBaseline` silently
proceeded past metadata-regen on a lincheck bump — same masking pattern.