### PR TITLE
docs(agents): split CI/release/verification traps to .github/AGENTS.md

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,238 @@
+# `.github/` — Workflow, release & verification traps
+
+Scope: `.github/workflows/`, `dependabot.yml`, dependency-graph submission,
+verification-metadata, Central Portal release. Library architecture and
+language traps live in the **root `AGENTS.md`** — read that first.
+
+## Commit & PR
+
+- **Conventional commits required** (strict type set: see `CONTRIBUTING.md`).
+- Keep history flat (`--ff-only`). FF merges are triggered by an exact `/ff`
+  or `/fast-forward` PR comment; `pr-fast-forward.yml` first verifies the
+  commenter has write/maintain/admin permission.
+- **Adding a new submodule** → also update `.github/workflows/build.yml`
+  (also called out in `settings.gradle.kts`).
+
+## `/ff` recursion-guard (load-bearing)
+
+A `/ff` land is a `git push` authored by `GITHUB_TOKEN`. GitHub suppresses
+workflow triggers for `GITHUB_TOKEN`-authored pushes (recursion guard). That
+silently breaks two pipelines after a `/ff` to `dev`:
+
+1. **`publishSnapshot` does NOT fire.** To publish a snapshot, push `dev`
+   with a real user/PAT, or dispatch the workflow manually — not via `/ff`.
+2. **`dependency-submission.yml` does NOT fire** → dep-graph stays stale →
+   lingering Security-tab alerts. After a `/ff` that should refresh deps:
+   `gh workflow run dependency-submission.yml --ref dev`.
+
+## `publishSnapshot` (in `build.yml`)
+
+- Auto-fires on `dev` push when the catalog version ends `-SNAPSHOT`, gated
+  `event==push && repo==fluxo-kt/fluxo-io && ref==default_branch`. A
+  feature-branch push does **not** publish.
+- The job already has a per-step `is_snapshot == 'true'` gate, so it fires
+  but no-ops when the catalogue version is non-SNAPSHOT.
+- Without the five publish secrets the publish steps **hard-fail** → false-red
+  (secrets absent, not publish broken). If noisy, gate via a preflight
+  `has_secrets` job — secrets are unreadable in a job-level `if:`. Do **not**
+  paper over with `continue-on-error` (masks real publish failures).
+
+## Release publication
+
+- **Central Portal only.** S01/OSSRH and legacy host APIs are dead;
+  workflows must use `publishToMavenCentral` with **manual Portal release**
+  (`automaticRelease = false`). Do not call `publishAndReleaseToMavenCentral`.
+- **Never re-add `jit` + `pack` (the well-known Linux-only Gradle build
+  service).** It does not support KMP (`jitpack#3853`); this lib has
+  Apple/Native targets → broken metadata-incomplete artifact. The
+  repository ban must stay.
+- **`useDokka = true`** applies Dokka only for non-SNAPSHOT publications in
+  fluxo-kmp-conf. Verify release docs with a temporary non-SNAPSHOT version
+  or release config; keep `dokka-base`/`templating-plugin` in verification
+  metadata.
+
+### Signing-secrets gap (open, maintainer-action)
+
+`release.yml` + `build.yml` reference `SIGNING_IN_MEMORY_KEY[_ID|_PASSWORD]`
+(also documented in `RELEASING.md`). The fluxo-kt **org** secrets store
+holds only `SIGNING_KEY` + `SIGNING_PASSWORD` (no `_ID` of any name). Latent
+since `b968333` because `release.yml` has never run and `publishSnapshot` is
+suppressed on `/ff`. Two unblock routes:
+
+1. Create org secrets matching workflow refs (`gpg --list-secret-keys
+   --keyid-format=long` derives the `_ID`).
+2. Edit workflow refs to use existing names + add only `SIGNING_KEY_ID`.
+   Keep `ORG_GRADLE_PROJECT_signingInMemoryKey` env-var name (vanniktech
+   reads that property).
+
+Until fixed, do not push a non-SNAPSHOT release tag — it surfaces here.
+
+## `pr-baseline.yml`
+
+Manual same-repository baseline-refresh workflow, **not** automatic
+Dependabot handling. It hard-restricts to `dependabot/*` head branches
+(`case "$head_ref" in dependabot/*) ;; *) exit 1 ;;`). Consequence: bumps
+that need a metadata regen on a non-Dependabot branch (e.g. an already-
+closed PR a maintainer wants to revive) require either reopening a
+Dependabot PR or modifying the branch filter (cross-cutting). See the
+Lincheck 3.6 case in memory.
+
+## Dependabot proposes untagged re-publishes
+
+Dependabot reads a registry's `<versions>` *list*, not `<latest>`/upstream
+tags — it can suggest an artifact the maintainer never blessed. **Rule:**
+before folding a dep/plugin bump, confirm a matching upstream tag/release
+AND registry `<latest>`; else keep the endorsed version and close the PR.
+Dep-verification checksums the bytes you declare, NOT "endorsed" — so this
+review is the only gate. Reference case in memory: `com.osacky.doctor 0.12.1`
+— no `v0.12.1` tag, Portal `<latest>` still 0.12.0, identical POM → re-cut.
+
+## Dependency-submission graph
+
+`DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=".*(Compile|Runtime)Classpath"`
+(full-string `String.matches`) is an **allowlist**, not a denylist. It ships
+only consumer-facing resolved classpaths. The earlier denylist
+`^(?!(classpath)).*` failed because project-qualified names like
+`:classpath` don't start with the literal, leaking AGP/protobuf/bouncycastle
+build tooling → phantom `security_update_dependency_not_found` Dependabot
+jobs. Excluding build tooling from the *consumer* graph is **accurate**
+(consumers never see it), not vuln-hiding.
+
+### Zombie maven alerts
+
+The pre-#29 `setup-gradle` auto-graph submitted a `settings.gradle.kts`
+manifest (buildscript classpath incl. tooling) under a *different
+correlator* than the live submitter. GitHub keeps the last snapshot per
+correlator indefinitely, never auto-evicts a stopped producer, and exposes
+**no API to read a submitted snapshot's correlator** (SBOM + legacy GraphQL
+are blind to submitted snapshots) — a targeted empty-snapshot eviction
+can't reach the orphan, so **dismiss `not_used`** (build tooling, never
+shipped). New orphans are structurally prevented (auto-graph off via
+`GITHUB_DEPENDENCY_GRAPH_ENABLED: false` + single stable-correlator
+submitter). Diagnose via the submitted-run artifact (ground truth, not the
+cached SBOM) + `gh api …/dependabot/alerts --jq '…manifest_path…'`.
+
+### `.kotlin-js-store/yarn.lock` npm alerts (benign, persistent)
+
+GitHub auto-detects the lockfile for security advisories — no per-path
+graph exclusion exists (inherent limit). Any flagged npm transitives are
+Kotlin/JS **dev-toolchain** deps, never shipped. If jobs get noisy, the
+only lever is an `npm` ecosystem block in `dependabot.yml` scoped to
+`/.kotlin-js-store` with a catch-all `ignore`. The PR-time
+`dependency-review` gate sees the same lockfile and fails only on **added**
+vulnerable deps; GitHub scopes every yarn.lock entry as `runtime` (mocha,
+typescript included), so `fail-on-scopes` can't filter them. Waive a proven
+dev-toolchain advisory per-GHSA via `allow-ghsas` (keeps low+ strictness
+for shipped JVM/actions deps) rather than blanket-raising
+`fail-on-severity`. Verify scope/manifest with the dependency-graph compare
+API (`gh api repos/<o>/<r>/dependency-graph/compare/<base>...<head>`).
+
+Regenerate the lockfile via `./gradlew kotlinUpgradeYarnLock` (run by
+`./updateBaseline`); do not hand-edit other `.kotlin-js-store/` files.
+
+## Action pins rot
+
+- Every remote action needs a 40-char SHA + `# vX.Y.Z` comment
+  (policy-enforced). When bumping a major, verify Node-runtime compat
+  (e.g. `actions/github-script` v7/Node20 → v9/Node24).
+- **Transitive rot is real:** a pinned action whose own deps are unpinned
+  can break later. `actionlint v1.0.3` crashed `ERR_PACKAGE_PATH_NOT_EXPORTED`
+  via an unpinned transitive `@actions/tool-cache` under
+  `actions/github-script@v7`.
+- **`setup-gradle` is special** — its allowed SHA is the hardcoded
+  `SETUP_GRADLE_PINNED_REF` constant in `VerifyBuildPolicyTask.java`.
+  Bumping the workflow pin requires editing that constant in the same
+  change.
+
+## `harden-runner` `egress-policy: block`
+
+Any host an action **transitively** reaches must be listed, and GitHub
+migrates those hosts. The actionlint job downloads its binary via
+`@actions/tool-cache` from a release asset `browser_download_url`, which
+302-redirects off `github.com` to **`release-assets.githubusercontent.com`**
+(current asset host, replacing legacy `objects.githubusercontent.com` —
+keep both listed). Cache-hit runs (push) hide the gap; cache-miss (PR) reds
+with `ECONNREFUSED`. Re-derive the real host for any release download:
+`curl -sIL <browser_download_url> | grep -i ^location`. Don't reverse-DNS
+the blocked IP — harden-runner reports the destination IP, not the
+hostname. Never "fix" this by downgrading `block`→`audit` (disables
+blocking).
+
+## Verification metadata (`gradle/verification-metadata.xml`)
+
+Regenerated by `./updateBaseline`; dep or plugin updates **must** refresh
+it with the dependency change.
+
+### PGP keyring committed, not keyserver-fetched
+
+`updateBaseline` passes `--export-keys`, writing
+`gradle/verification-keyring.keys` (ASCII, tracked, reviewable; the binary
+`.gpg` is gitignored). CI verifies signatures against this local keyring —
+never public keyservers.
+
+**Dirty-home trap:** a green local `./gradlew check` does NOT prove CI will
+pass. Verification fires only when an artifact *enters* a
+`GRADLE_USER_HOME` (download time), so a populated home silently passes
+artifacts CI would reject; a warm daemon and a stored config-cache entry
+further skip re-resolution. Three masking layers → the ONLY faithful local
+repro is a **fresh empty `GRADLE_USER_HOME`** (copy in `wrapper/` to skip
+the distro download, leave `modules-2` empty) run with `--no-daemon` and
+cleared `.gradle/configuration-cache`. The same trap hides missing keys:
+without the committed keyring CI must fetch every `<trusted-key>` from
+flaky keyservers and reds on ~126 buildscript-classpath artifacts. Keep
+keyservers **enabled** (no `<key-servers enabled="false"/>`): the keyring
+satisfies verify-time, and the fallback is what lets `--refresh-keys` fetch
+material for newly-added deps — disabling it would break the regen writer
+path. After a dep change, re-run `./updateBaseline` and confirm every
+metadata `<trusted-key>` id has matching key material in the keyring before
+pushing.
+
+### Trust-by-coordinate vs. checksum (general rule)
+
+**Verify shipped/library artifacts by checksum; trust non-shipped build
+infrastructure (BOM/parent POMs + toolchain binaries) by coordinate.**
+
+- `junit-bom`, `kotlinx-coroutines-bom`, `jackson-base` (Jackson parent
+  POM): BOM/parent metadata POMs the CC path drags onto the buildscript
+  classpath at versions `updateBaseline` (forced `--no-CC`) never resolves
+  → `checksum is missing from verification metadata` for a `.pom` on the
+  Plugin Portal. Per-version `<component>` entries are fragile —
+  coroutines-bom had 1.7.3/1.9.0/1.11.0 yet CI pulled 1.8.0 → red. Trust
+  by coordinate (`<trusted-artifacts>`).
+- Toolchain binaries (`org.nodejs:node`, `com.github.webassembly:binaryen`):
+  platform-multiplied + version-churned, so `updateBaseline` captures only
+  the runner's own variant. Trust by coordinate too — non-shipped build
+  infra from official immutable sources.
+
+Code JARs stay **checksum-verified**.
+
+### `updateBaseline` script gotchas
+
+- Uses an isolated `.gradle/update-baseline` Gradle user home when
+  `GRADLE_USER_HOME` is unset. Reason: the shared global daemon registry
+  can receive stop signals from other worktrees and kill long baseline
+  runs.
+- Forces `--no-CC` to write metadata. Versions only resolved under
+  config-cache instrumentation (CI path) are unreachable to the write-pass
+  → some transitives (lincheck-on-bump, parent POMs) need a primed cache
+  before `./updateBaseline` can capture them.
+
+## Repository policy enforcement
+
+`verifyBuildPolicy` enforces non-negotiable build/security invariants
+including pinned actions/runners, Central Portal, TS API checks, and Dokka.
+**Threat model is accidental-regression, not anti-malicious:** it scans
+text for required/forbidden literals, so it is bypassable by string concat
+and asserts literal *presence*, not effective value (both `useDokka = true`
+and a later `= false` present would pass). Don't mistake it for
+tamper-proof; don't gold-plate it either. **It scans tracked docs too**
+(incl. `AGENTS.md` / `CLAUDE.md`), so never write a forbidden literal
+verbatim in Markdown — name the referenced service descriptively; a bare
+URL occurrence reds the gate.
+
+## Pointers
+
+- Library architecture, RAD recipe, Java surface → root `AGENTS.md`
+- Release flow → `../RELEASING.md`
+- Security policy / vuln reporting → `../SECURITY.md`
+- Commit + PR rules → `../CONTRIBUTING.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,17 +3,23 @@
 Kotlin Multiplatform read-only random-access I/O lib. Single published
 module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
 
+Workflow / release / verification-metadata traps live in
+[`.github/AGENTS.md`](.github/AGENTS.md). Auxiliary docs:
+[`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md),
+[`RELEASING.md`](RELEASING.md), [`SECURITY.md`](SECURITY.md),
+[`ROADMAP.md`](ROADMAP.md).
+
 ## Vibe & principles
-- **Small, fast, allocation-careful, no deps.** CONTRIBUTING.md says: don't
-  add deps or major new functionality. `kotlinx-coroutines` and
+
+- **Small, fast, allocation-careful, no deps.** `CONTRIBUTING.md` says:
+  don't add deps or major new functionality. `kotlinx-coroutines` and
   `androidx-annotation` are `compileOnly` — consumers opt in.
 - **Tests use real temp files, not mocks.** Every JVM impl is exercised
   through `AbstractRandomAccessDataTest` with concurrency + randomized
   reads. Tests live ONLY in `jvmTest`.
-- **Public API is locked** by JVM/KLIB Binary Compatibility Validator and TS
-  API dumps. Dumps under
-  `fluxo-io-rad/api/`. Any intended ABI change must be reflected via
-  `apiDump`. CI fails on drift.
+- **Public API is locked** by JVM/KLIB Binary Compatibility Validator and
+  TS API dumps. Dumps under `fluxo-io-rad/api/`. Any intended ABI change
+  must be reflected via `apiDump`. CI fails on drift.
 - **Java surface is shaped by file-level
   `@file:JvmName("Rad") @file:JvmMultifileClass`** on every
   `*RadAccessor.kt`. Kotlin `RadByteBufferAccessor(…)` becomes Java
@@ -26,13 +32,15 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   into `InternalFluxoIoApi`, so internal accessors don't sprinkle `@OptIn`.
 
 ## Layout
+
 - `:fluxo-io-rad` — only published module.
   - `commonMain` — `expect interface RandomAccessData` + `ByteArrayRad`.
   - `commonJvmMain` — JVM+Android impl set (`ByteBuffer`, mmap,
     `FileChannel`, `RandomAccessFile`, `SeekableByteChannel`, stream
     factories, async).
   - `nonJvmMain` — JS / Native / Wasm-JS, `ByteArray`-only.
-    Wasm-WASI is **explicitly disabled** (`allDefaultTargets(wasmWasi = false)`).
+    Wasm-WASI is **explicitly disabled**
+    (`allDefaultTargets(wasmWasi = false)`).
 - Root `build.gradle.kts` — umbrella via `fkcSetupRaw {…}`, Kover
   aggregation, resolves `extra["androidJar"]` from `local.properties` /
   `ANDROID_SDK_ROOT` / `ANDROID_HOME` so non-Android source sets can
@@ -43,6 +51,7 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   line=100, indent=4 for `.kt`/`.kts`).
 
 ## Core architecture
+
 - `RandomAccessData` is `expect interface` annotated
   `@SubclassOptInRequired(InternalFluxoIoApi::class)`. JVM `actual` adds
   `Closeable`, `ByteBuffer` reads, `asInputStream()`, `transferTo`,
@@ -52,51 +61,57 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `SharedDataAccessor`; closing decrements; resource frees on the last
   close. **Each subsection MUST be closed independently** — otherwise the
   underlying handle leaks. Conversely, **`close()` is idempotent per holder**
-  (`AccessorAwareRad` has a private atomicfu `closed` guard, `final` override):
-  a holder owns exactly one retain, so it must release at most once. Without the
-  guard a `Closeable`-legal double-close (`use{}` + manual, defensive close)
-  would decrement the *shared* refcount twice and prematurely free the resource
-  still used by the parent/siblings — `IOException` for file impls, a **JVM
-  `SIGABRT` use-after-free** for direct/mmap `ByteBuffer`. Regression:
+  (`AccessorAwareRad` has a private atomicfu `closed` guard, `final`
+  override): a holder owns exactly one retain, so it must release at most
+  once. Without the guard a `Closeable`-legal double-close (`use{}` +
+  manual, defensive close) would decrement the *shared* refcount twice and
+  prematurely free the resource still used by parent/siblings —
+  `IOException` for file impls, a **JVM `SIGABRT` use-after-free** for
+  direct/mmap `ByteBuffer`. Regression:
   `AbstractRandomAccessDataTest.doubleClosingSubsectionKeepsSharedResourceForParent`
   runs across every impl, so a new RAD that drops the guard can't pass CI.
 - **Read-after-(last-)close is guarded at the resource-owner layer, not
-  `AccessorAwareRad`.** Once the shared resource is freed (`isOpen` false), a read
-  must fail with a clean `IOException`, never touch freed state. The guard CANNOT
-  live in `AccessorAwareRad.read`/`readFrom`: per-impl perf overrides
-  (`readByteAt0`, `read(ByteBuffer,position)`, `transferTo`) bypass it and hit
-  `access`/`access.api` directly. It lives in `SharedDataAccessor.checkOpen()`
-  (`internal` extension in `commonJvmMain` — the common `expect class IOException`
-  has no message ctor, and the hazard is JVM-only). Only **ByteBuffer** (mmap/direct
-  → native use-after-free **SIGABRT** after unmap) and **StreamFactory** (re-pool
-  into an already-drained pool → silent stream **leak**) need it; the 4 file/channel
-  impls self-throw `ClosedChannelException`/`IOException` on a closed handle.
-  **ByteArray is deliberately exempt** — no releasable resource, `close()` is a
-  no-op, guarding the fastest impl's hot path buys no safety (`RandomAccessDataArrayTest`
-  overrides the test to assert reads stay valid). **Concurrent close-during-read is safe by
+  `AccessorAwareRad`.** Once the shared resource is freed (`isOpen` false),
+  a read must fail with a clean `IOException`, never touch freed state.
+  The guard CANNOT live in `AccessorAwareRad.read`/`readFrom`: per-impl
+  perf overrides (`readByteAt0`, `read(ByteBuffer,position)`, `transferTo`)
+  bypass it and hit `access`/`access.api` directly. It lives in
+  `SharedDataAccessor.checkOpen()` (`internal` extension in `commonJvmMain`
+  — the common `expect class IOException` has no message ctor, and the
+  hazard is JVM-only). Only **ByteBuffer** (mmap/direct → native
+  use-after-free **SIGABRT** after unmap) and **StreamFactory** (re-pool
+  into an already-drained pool → silent stream **leak**) need it; the 4
+  file/channel impls self-throw `ClosedChannelException`/`IOException` on a
+  closed handle. **ByteArray is deliberately exempt** — no releasable
+  resource, `close()` is a no-op, guarding the fastest impl's hot path
+  buys no safety (`RandomAccessDataArrayTest` overrides the test to assert
+  reads stay valid). **Concurrent close-during-read is safe by
   construction, not by a flaky timing test:** `isOpen` flips `false` in
-  `SharedCloseable.releaseRetain()` *before* `onSharedClose()` runs (verified
-  `SharedCloseable.kt` `releaseRetain`→`onSharedClose`; locked by
-  `SharedCloseableTest.resourceReleaseObservesClosedState`), and reads share the resource
-  monitor with the release — ByteBuffer's unmap is `synchronized(api)` (this made
-  `readByteAt0` go `synchronized` — a deliberate hot-path cost for memory safety) and
-  StreamFactory rechecks `isOpen` **under the pool lock** (also where the drain runs). So no
-  interleaving lets a read touch freed state — and it's not just argued: `RadConcurrentCloseTest`
-  latch-freezes a real in-flight read mid-close (no sleeps), RED without each guard
-  (`unmapWaitsForInFlightRead` → close finishes mid-read; `streamRePooled…` → leaked stream).
-  Regression:
-  `AbstractRandomAccessDataTest.readingClosedHolderThrowsNotCrashes` runs across every impl and
-  exercises **all four** resource-touching entry points (`readByteAt`, `readFrom`,
-  `read(ByteBuffer)`, `transferTo`) — RED-bisected, so dropping the guard from any one override
-  reds it (covering fewer paths would let a UAF leak through the rest). NB: this rejects reads
-  after the *shared* resource is freed, NOT per-holder — reading a closed subsection whose
-  parent is still open succeeds (by design).
+  `SharedCloseable.releaseRetain()` *before* `onSharedClose()` runs
+  (verified `SharedCloseable.kt` `releaseRetain`→`onSharedClose`; locked
+  by `SharedCloseableTest.resourceReleaseObservesClosedState`), and reads
+  share the resource monitor with the release — ByteBuffer's unmap is
+  `synchronized(api)` (this made `readByteAt0` go `synchronized` — a
+  deliberate hot-path cost for memory safety) and StreamFactory rechecks
+  `isOpen` **under the pool lock** (also where the drain runs). So no
+  interleaving lets a read touch freed state — and it's not just argued:
+  `RadConcurrentCloseTest` latch-freezes a real in-flight read mid-close
+  (no sleeps), RED without each guard (`unmapWaitsForInFlightRead` →
+  close finishes mid-read; `streamRePooled…` → leaked stream). Regression:
+  `AbstractRandomAccessDataTest.readingClosedHolderThrowsNotCrashes` runs
+  across every impl and exercises **all four** resource-touching entry
+  points (`readByteAt`, `readFrom`, `read(ByteBuffer)`, `transferTo`) —
+  RED-bisected, so dropping the guard from any one override reds it
+  (covering fewer paths would let a UAF leak through the rest). NB: this
+  rejects reads after the *shared* resource is freed, NOT per-holder —
+  reading a closed subsection whose parent is still open succeeds
+  (by design).
 - `SharedDataAccessor` owns the JVM resource and the only
   `read(bytes, position, offset, length)` primitive.
-  `onSharedClose()` is `final`; release the API in `protected open fun releaseApi()`
-  — the template always closes the `resources` array even if release throws.
-  Direct `onSharedClose` overrides are compile-blocked (see
-  `SharedDataAccessorReleaseApiTest`).
+  `onSharedClose()` is `final`; release the API in
+  `protected open fun releaseApi()` — the template always closes the
+  `resources` array even if release throws. Direct `onSharedClose`
+  overrides are compile-blocked (see `SharedDataAccessorReleaseApiTest`).
   `AccessorAwareRad<A>` wraps it with offset/size + bounds checks
   (`fluxo.io.util.IoUtil`). `BasicRad` (expect/actual) carries the JVM
   common impl: `readByteAt`, `transferTo`, `read(ByteBuffer, position)`,
@@ -117,27 +132,28 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
   `Async*Channel` after cancellation is unsafe.
 
 ## Build, test, regen baselines
+
 ```
 ./gradlew check                    # full verify (BCV apiCheck, kover, detekt, AGP lint wiring, depGuard, tests)
 ./gradlew :fluxo-io-rad:jvmTest    # JVM unit tests
 ./gradlew :fluxo-io-rad:apiDump    # refresh BCV after intentional API change
 ./updateBaseline                   # CANONICAL regen: verification metadata+yarnLock+apiDump+depGuardBaseline (CI=true RELEASE=true, no build/config cache, isolated .gradle/update-baseline home unless GRADLE_USER_HOME is set)
 ```
+
 - Configuration cache is on with `problems=fail` and `max-problems=0`.
   Don't capture `Project` or build-script instances in task actions.
 - Tests use `runTest(timeout = 9.seconds)`. Concurrency is exercised by
   `AbstractRandomAccessDataTest.testConcurrency` against a real temp file.
 - Lincheck models must keep each `@Operation` to one API action. Do not
-  combine mutation plus later observation (for example `close(); isOpen`) in
-  one operation; expose the observation as a separate operation or deterministic
-  regression test.
-- CI runs across macOS/Windows/Ubuntu on JDK 21. SNAPSHOT publishing is a
-  separate macOS job after the matrix succeeds, only on default-branch pushes
-  when the catalog version ends with `-SNAPSHOT`. `pr-baseline.yml` is a
-  manual same-repository baseline-refresh workflow, not automatic Dependabot
-  handling.
+  combine mutation plus later observation (for example `close(); isOpen`)
+  in one operation; expose the observation as a separate operation or
+  deterministic regression test.
+- CI runs across macOS/Windows/Ubuntu on JDK 21.
+- For workflow / release / verification-metadata traps see
+  [`.github/AGENTS.md`](.github/AGENTS.md).
 
 ## Adding a new RAD impl (canonical recipe)
+
 1. JVM: `internal class FooRad(access, offset, size) :
    AccessorAwareRad<FooAccess>(access, offset, size)`. Inner
    `FooAccess(api, resources) : SharedDataAccessor(resources)` exposes
@@ -145,216 +161,99 @@ module `:fluxo-io-rad`. **Alpha** — public API may shift. Apache-2.0.
    `getSubsection0` returns `FooRad(access, globalPosition, length)` —
    same `access`, parent retains.
 2. Optional perf overrides: `read(ByteBuffer, position)` and
-   `transferTo(WritableByteChannel, …)` (see `FileChannelRad`). **Any override
-   that touches `access`/`access.api` for a releasable resource must call
-   `checkOpen()` first** (read-after-close UAF/leak), unless the handle itself
-   self-throws once closed (channels/`RandomAccessFile`). The cross-impl
-   `readingClosedHolderThrowsNotCrashes` exercises these four entry points, so a
-   missing guard reds CI.
+   `transferTo(WritableByteChannel, …)` (see `FileChannelRad`). **Any
+   override that touches `access`/`access.api` for a releasable resource
+   must call `checkOpen()` first** (read-after-close UAF/leak), unless the
+   handle itself self-throws once closed (channels/`RandomAccessFile`).
+   The cross-impl `readingClosedHolderThrowsNotCrashes` exercises these
+   four entry points, so a missing guard reds CI.
 3. Public factory in `FooRadAccessor.kt` with
    `@file:JvmName("Rad") @file:JvmMultifileClass` and `@JvmName("forFoo")`
    per overload. Mark `@Blocking` if the constructor opens resources.
 4. Test: extend `AbstractRandomAccessDataTest(factory)`.
 5. Run `./updateBaseline`. Inspect `api/jvm/fluxo-io-rad.api` diff
    before committing.
+6. **Adding a new submodule** → also update
+   `.github/workflows/build.yml` (called out in `settings.gradle.kts`).
 
-## Conventions and traps
-- **Conventional commits required**, strict type set listed in
-  CONTRIBUTING.md. Keep history flat (`--ff-only`); fast-forward merges
-  are triggered by an exact `/ff` or `/fast-forward` PR comment after the
-  workflow verifies the commenter has write, maintain, or admin permission.
-- **Adding a new submodule** → also update `.github/workflows/build.yml`
-  (called out in `settings.gradle.kts`).
+## Conventions and traps (library / build)
+
 - **Mmap limit**: only files < 2 GiB (`Int.MAX_VALUE`) work with
   `RadByteBufferAccessor(File|FileChannel|FileDescriptor|FileInputStream)`.
 - **Don't recommend `RadAsyncFileChannelAccessor`** — deprecated, slow,
   direct-buffer OOM-prone. Same for `RadMemoryMappedAccessor` →
   `RadByteBufferAccessor`.
 - **`fluxo.io.nio.Java8BufferCompat`** (`flipCompat`, `clearCompat`, …)
-  must be used in JVM source instead of raw `Buffer.flip()` to dodge
-  the JDK 9 covariant-override `NoSuchMethodError`.
+  must be used in JVM source instead of raw `Buffer.flip()` to dodge the
+  JDK 9 covariant-override `NoSuchMethodError`. It's intentionally kept
+  for source compatibility — see `ROADMAP.md` "triggered modernization".
 - **Coroutines is `compileOnly`** in lib code. Consumers using suspend
   APIs must depend on `kotlinx-coroutines-core`.
 - **AGP 9 Android-KMP trap:** `androidMain` must explicitly depend on
   `commonJvmMain` here, otherwise Android compilation cannot see JVM
   actuals. Consumer keep rules are not published by default; use
   `android.optimization.consumerKeepRules { publish = true; file(...) }`
-  and verify `bundleAndroidMainAar` contains `proguard.txt`.
-- **No `updateLintBaseline` task under AGP 9 Android-KMP** here. Keep
-  `updateBaseline` to executable tasks only; verify available lint tasks with
-  `./gradlew tasks --all --quiet | rg -i 'lint|baseline'` before adding one.
-- `updateBaseline` uses an isolated `.gradle/update-baseline` Gradle user home
-  when `GRADLE_USER_HOME` is unset. The shared global daemon registry can receive
-  stop signals from other worktrees and kill long baseline runs.
-- `useDokka = true` only applies Dokka for non-SNAPSHOT publications in
-  fluxo-kmp-conf. Verify release docs with a temporary non-SNAPSHOT version or
-  release config; keep `dokka-base`/`templating-plugin` in verification metadata.
-- **Central Portal only.** S01/OSSRH and legacy host APIs are dead here;
-  workflows must use `publishToMavenCentral`, with manual Portal release.
-- **Never re-add JitPack.** It is Linux-only and does not support KMP
-  (jitpack#3853); this lib has Apple/Native targets, so a JitPack build emits a
-  broken metadata-incomplete artifact. Removal + the JitPack repository ban are
-  correct — keep both.
-- **`publishSnapshot` (build.yml) auto-fires on a `dev` push** when the catalogue
-  version ends `-SNAPSHOT` (gated `event==push && repo==fluxo-kt/fluxo-io &&
-  ref==default_branch`); a feature-branch push does not publish. **Trap: a `/ff` land
-  does NOT trigger it** — the FF push is authored by `GITHUB_TOKEN`, and GitHub
-  suppresses workflow triggers for `GITHUB_TOKEN` pushes (recursion guard). To publish
-  a snapshot, push `dev` with a real user/PAT or dispatch manually — not via `/ff`.
-  Without the five publish secrets the publish steps hard-fail → a false-red (secrets
-  absent, not publish broken); if it turns noisy, gate via a preflight `has_secrets`
-  job (secrets are unreadable in a job-level `if:`), NOT `continue-on-error` (masks
-  real publish failures).
-- **dep-submission graph is an allowlist, not a denylist.**
-  `DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS=".*(Compile|Runtime)Classpath"` (full-
-  string `String.matches`) ships only consumer-facing resolved classpaths. The
-  denylist `^(?!(classpath)).*` failed because project-qualified names like
-  `:classpath` don't start with the literal, leaking AGP/protobuf/bouncycastle
-  build tooling into the submitted graph → phantom
-  `security_update_dependency_not_found` Dependabot jobs. Excluding build tooling
-  from the *consumer* graph is accurate (consumers never see it), not vuln-hiding.
-  **Stale graph after `/ff` (same GITHUB_TOKEN root as publishSnapshot):** the graph
-  refreshes only when `dependency-submission.yml` runs (`push` to `dev` / dispatch /
-  Mon cron); a `/ff` land is GITHUB_TOKEN-authored → no run → stale graph + lingering
-  Security-tab alerts. After a `/ff` that should refresh deps, run
-  `gh workflow run dependency-submission.yml --ref dev`. The 4 `.kotlin-js-store/yarn.lock`
-  npm alerts persist regardless (GitHub auto-detects that lockfile; no per-path
-  exclusion — inherent, benign). **Zombie maven alerts:** the pre-#29 `setup-gradle`
-  auto-graph submitted a `settings.gradle.kts` manifest (buildscript classpath incl.
-  tooling) under a *different correlator* than the live submitter; GitHub keeps the last
-  snapshot per correlator indefinitely, never auto-evicts a stopped producer, and exposes
-  **no API to read a submitted snapshot's correlator** (SBOM + legacy GraphQL are blind to
-  submitted snapshots) → a targeted empty-snapshot eviction can't reach the orphan, so
-  **dismiss `not_used`** (build tooling, never shipped). New orphans are structurally
-  prevented (auto-graph off via `GITHUB_DEPENDENCY_GRAPH_ENABLED: false` + single
-  stable-correlator submitter). Diagnose via the submitted-run artifact (ground truth,
-  not the cached SBOM) + `gh api …/dependabot/alerts --jq '…manifest_path…'`.
-- **Dependabot proposes untagged re-publishes; adopt only endorsed versions.** It reads
-  a registry's `<versions>` *list*, not `<latest>`/upstream tags, so it can suggest an
-  artifact the maintainer never blessed. Rule: before folding a dep/plugin bump, confirm
-  a matching upstream tag/release AND registry `<latest>`; else keep the endorsed version
-  and close the PR. Dep-verification checksums the bytes you declare, NOT "endorsed" — so
-  this review is the only gate. (Case: `com.osacky.doctor 0.12.1` — no `v0.12.1` tag,
-  Portal `<latest>` still 0.12.0, POM identical → a re-cut, not an upgrade.)
-- **Action pins rot.** Every remote action needs a 40-char SHA + `# vX.Y.Z`
-  comment (policy-enforced); when bumping a major, verify Node-runtime compat
-  (e.g. github-script v7/Node20 → v9/Node24). Pinned-action rot is real: a pinned
-  action whose *own* deps are unpinned can break later (actionlint v1.0.3 crashed
-  `ERR_PACKAGE_PATH_NOT_EXPORTED` via an unpinned transitive `@actions/tool-cache`
-  under github-script@v7). `setup-gradle` is special — its allowed SHA is the
-  hardcoded `SETUP_GRADLE_PINNED_REF` constant in `VerifyBuildPolicyTask.java`;
-  bumping the workflow pin requires editing that constant in the same change.
-- **harden-runner `egress-policy: block` allowlists rot too.** Any host an action
-  *transitively* reaches must be listed, and GitHub migrates those hosts. The
-  actionlint job downloads its binary via `@actions/tool-cache` from a release
-  asset `browser_download_url`, which 302-redirects off `github.com` to
-  **`release-assets.githubusercontent.com`** (the current asset host, replacing the
-  legacy `objects.githubusercontent.com` — keep both listed). Cache-hit runs (push)
-  hide the gap; cache-miss (PR) reds with `ECONNREFUSED`. To re-derive the real host
-  for any release download: `curl -sIL <browser_download_url> | grep -i ^location`.
-  Don't reverse-DNS the blocked IP — harden-runner reports the destination IP, not
-  the hostname. Never "fix" this by downgrading `block`→`audit` (disables blocking).
-- **Don't strand local-only branches.** Push WIP to `origin` (bus-factor; a
-  single local copy is what stranded the toolchain modernization). Divergence
-  happens — expect to rebase onto `origin/dev` before an `--ff-only` land.
+  and verify `bundleAndroidMainAar` contains `proguard.txt`. There is **no
+  `:fluxo-io-rad:lint` task** under AGP 9 Android-KMP here; use the
+  discovered lint packaging tasks (`compileLint`,
+  `androidCompileLintChecks`, `bundleAndroidMainLocalLintAar`) plus
+  `check`. There is **no `updateLintBaseline` task** either — keep
+  `updateBaseline` to executable tasks only; verify available lint tasks
+  with `./gradlew tasks --all --quiet | rg -i 'lint|baseline'` before
+  adding one.
+- **Never re-add the well-known Linux-only Gradle build service** (`jit` +
+  `pack`). It does not support KMP (`jitpack#3853`); this lib has
+  Apple/Native targets, so its build emits a broken metadata-incomplete
+  artifact. Removal + the repository ban are correct — keep both. (See
+  also `.github/AGENTS.md` "Release publication".)
 - Build floors are deliberate: `javaLangTarget=17`, `androidMinSdk=21`,
   `kotlinLangVersion=2.1`. Do not raise Kotlin language without fresh
   fluxo-kmp-conf/Detekt compatibility evidence.
-- `Java8BufferCompat` is intentionally kept for source compatibility.
-- `kotlinx-io`, Okio, and JMH are catalogue-reserved; don't wire them without
-  an actual feature need.
+- `kotlinx-io`, Okio, and JMH are catalogue-reserved; don't wire them
+  without an actual feature need.
 - JSR305 stays at `3.0.2`; upstream has no newer release.
 - `kotlin.concurrent.atomics` is still experimental; keep AtomicFU.
-- TS API checks, KLIB/JVM BCV, and Dokka publication jars are enforced.
 - Keep the explicit `apiValidation { klib { enabled = true } }` in
   `:fluxo-io-rad`; fluxo-kmp-conf `klibValidationEnabled = true` alone did
   not enable BCV 0.18 KLIB tasks here.
-- Dependency verification metadata is regenerated by `./updateBaseline`; dep
-  or plugin updates must refresh it with the dependency change.
-- **PGP key material is committed, not keyserver-fetched.** `updateBaseline`
-  passes `--export-keys`, writing `gradle/verification-keyring.keys` (ASCII,
-  tracked, reviewable; the binary `.gpg` is gitignored). CI verifies signatures
-  against this local keyring — never public keyservers. **Dirty-home trap:** a
-  green local `./gradlew check` does NOT prove CI will pass. Verification fires
-  only when an artifact *enters* a `GRADLE_USER_HOME` (download time), so a
-  populated home silently passes artifacts CI would reject; a warm daemon and a
-  stored config-cache entry further skip re-resolution. Three masking layers →
-  the ONLY faithful local repro is a **fresh empty `GRADLE_USER_HOME`** (copy in
-  `wrapper/` to skip the distro download, leave `modules-2` empty) run with
-  `--no-daemon` and cleared `.gradle/configuration-cache`. The same trap hides
-  missing keys: without the committed keyring CI must fetch every `<trusted-key>`
-  from flaky keyservers and reds on ~126 buildscript-classpath artifacts. Keep keyservers *enabled* (no
-  `<key-servers enabled="false"/>`): the keyring satisfies verify-time, and the
-  fallback is what lets `--refresh-keys` fetch material for newly-added deps —
-  disabling it would break the regen writer path. After a dep change, re-run
-  `./updateBaseline` and confirm every metadata `<trusted-key>` id has matching
-  key material in the keyring before pushing.
-- **`junit-bom` is trusted by coordinate** (`<trusted-artifacts>`), not
-  checksummed. It is a transitive BOM *platform* on the buildscript classpath;
-  its per-version `.module` variants resolve only during config-cache
-  instrumentation, which `--write-verification-metadata` (forced `--no-CC`)
-  cannot reach, so `updateBaseline` *cannot* auto-generate their sha256. Trust
-  the BOM by coordinate (metadata-only, no code, version-proof). Do NOT add
-  per-version sha256 — it recreates the catch-22 on the next junit bump.
-  **Same class, same fix for `kotlinx-coroutines-bom` and `jackson-base`**
-  (Jackson parent POM): BOM/parent metadata POMs the CC path drags onto the
-  buildscript classpath at versions `updateBaseline` (`--no-CC`) never resolves.
-  Symptom is `checksum is missing from verification metadata` for a `.pom` on the
-  Plugin Portal. The fragile fix is per-version `<component>` entries — coroutines-bom
-  had 1.7.3/1.9.0/1.11.0 yet CI pulled 1.8.0 → red. Trust the coordinate instead;
-  code JARs stay checksum-verified. The same single-OS limitation hits **toolchain
-  binaries** (`org.nodejs:node`, `com.github.webassembly:binaryen`): platform-
-  multiplied + version-churned, so `updateBaseline` captures only the runner's own
-  variant (was darwin-arm64-only → linux/windows CI red). Trust these by coordinate
-  too — non-shipped build infra from official immutable sources; shipped artifacts
-  stay checksummed. General rule: **verify shipped/library artifacts by checksum;
-  trust non-shipped build infrastructure (BOM/parent POMs + toolchain binaries) by
-  coordinate.**
-- `verifyBuildPolicy` enforces non-negotiable build/security invariants,
-  including pinned actions/runners, Central Portal, TS API checks, and Dokka.
-  **Threat model is accidental-regression, not anti-malicious:** it scans text
-  for required/forbidden literals, so it is bypassable by string concat
-  (`"jit"+"pack.io"`) and asserts literal *presence*, not effective value (both
-  `useDokka = true` and a later `= false` present would pass). Don't mistake it
-  for tamper-proof; don't gold-plate it either. It scans tracked **docs** too
-  (incl. AGENTS.md/CLAUDE.md), so never write a forbidden literal verbatim in
-  Markdown — name it descriptively (e.g. "the JitPack repository"); a bare
-  occurrence reds the gate (it bit the JitPack-ban note once).
-- AGP 9 Android-KMP has no `:fluxo-io-rad:lint` task here; use the discovered
-  lint packaging tasks (`compileLint`, `androidCompileLintChecks`,
-  `bundleAndroidMainLocalLintAar`) plus `check`.
 - Current warning debt is upstream/plugin-shaped: Detekt calls deprecated
-  Gradle `ReportingExtension.file`, Kotlin/JS resolves `*NpmAggregated` during
-  configuration, and `Java8BufferCompat` keeps Kotlin internal `InlineOnly` for
-  source-compatible Java 8 buffer wrappers.
+  Gradle `ReportingExtension.file`, Kotlin/JS resolves `*NpmAggregated`
+  during configuration, and `Java8BufferCompat` keeps Kotlin internal
+  `InlineOnly` for source-compatible Java 8 buffer wrappers.
 - Generated/build outputs (`build/`, `.gradle/`, `.kotlin/`) — never edit;
-  never commit. `.kotlin-js-store/yarn.lock` is tracked baseline output and is
-  regenerated via `./gradlew kotlinUpgradeYarnLock` (run by `updateBaseline`);
-  do not edit other `.kotlin-js-store/` files. GitHub auto-detects this lockfile
-  for security advisories with no per-path graph exclusion (inherent limit); any
-  flagged npm transitives are Kotlin/JS *dev-toolchain* deps, never shipped —
-  benign. If the jobs get noisy, the only lever is an `npm` ecosystem block in
-  `dependabot.yml` scoped to `/.kotlin-js-store` with a catch-all `ignore`.
-  The PR-time `dependency-review` gate sees the same lockfile and fails only on
-  **added** vulnerable deps. GitHub scopes every yarn.lock entry as `runtime`
-  (mocha, typescript included), so `fail-on-scopes` can't filter them; waive a
-  proven dev-toolchain advisory per-GHSA via `allow-ghsas` (keeps low+ strictness
-  for shipped JVM/actions deps) rather than blanket-raising `fail-on-severity`.
-  Verify scope/manifest with the dependency-graph compare API
-  (`gh api repos/<o>/<r>/dependency-graph/compare/<base>...<head>`).
+  never commit. `.kotlin-js-store/yarn.lock` is tracked baseline output
+  regenerated via `./gradlew kotlinUpgradeYarnLock` (run by
+  `./updateBaseline`); do not edit other `.kotlin-js-store/` files.
 - Project flags in `gradle.properties` (`MAX_DEBUG`, `COMPOSE_METRICS`,
   `USE_KOTLIN_DEBUG`, `LOAD_KMM_CODE_COMPLETION`) are read by
   `fluxo-kmp-conf`; semantics live in that plugin.
 
+## Process
+
+- **Conventional commits required** (strict type set: `CONTRIBUTING.md`).
+  Keep history flat (`--ff-only`); FF merges are triggered by an exact
+  `/ff` or `/fast-forward` PR comment after the workflow verifies the
+  commenter has write/maintain/admin permission. See `.github/AGENTS.md`
+  for the `GITHUB_TOKEN` recursion-guard side-effects.
+- **Don't strand local-only branches.** Push WIP to `origin` (bus-factor;
+  a single local copy is what stranded the toolchain modernization).
+  Divergence happens — expect to rebase onto `origin/dev` before an
+  `--ff-only` land.
+
 ## Surprises rule (READ THIS)
+
 **If anything in this repo surprises you — a build flag, a hidden opt-in,
 a deprecated alias still wired up, an ABI-dump diff that looks innocent
-but isn't — TELL THE USER and append a brief note here in AGENTS.md so
-the next agent doesn't have to relearn it.** Memory > recovery.
+but isn't — TELL THE USER and append a brief note here in `AGENTS.md`
+(library/architecture) or `.github/AGENTS.md` (workflow/release/
+verification) so the next agent doesn't have to relearn it.**
+Memory > recovery.
 
 ## Pointers
+
 - User-facing usage / platform matrix → `README.md`
 - Commit + PR rules → `CONTRIBUTING.md`
+- Release flow → `RELEASING.md`
 - Roadmap / known gaps → `ROADMAP.md`
 - Build behaviour comes from `io.github.fluxo-kt.fluxo-kmp-conf`
   (`fkcSetupRaw`/`fkcSetupMultiplatform`); when something Gradle-side is


### PR DESCRIPTION
## Summary

Root `AGENTS.md` had grown to 24.7K chars / 361 lines after accumulating workflow, release, and verification-metadata field-knowledge across PRs #38/#39/#40. 18 of 33 "Conventions and traps" bullets were CI/workflow-specific (55%) — past the documented threshold for splitting to a scoped sub-doc.

- Move workflow / release / verification-metadata traps to a new `.github/AGENTS.md` so they autoload on workflow edits and stay out of the library/architecture context that source-editing agents need first.
- Root keeps library design, the `SharedCloseable` / `checkOpen` safety contract, build floors, and process; one-line pointers cross-reference the new doc.
- Document the `SIGNING_IN_MEMORY_KEY[_ID|_PASSWORD]` org-secrets gap (was memory-only) — surfaces on first real release-tag push; needed for PR #41 unblock.
- Drop two internal duplicates (AGP-9 no-lint folded into AGP-9 trap bullet; bare "Java8BufferCompat kept" folded into prescriptive bullet).

**Net:** root 14.9K chars / 260 lines (-40%); new `.github/AGENTS.md` 12.4K chars / 238 lines. Both well under per-file caps.

## Test plan

- [x] `verifyBuildPolicy` text-scan hygiene — no raw forbidden URL literals (`grep -nE 'jit""pack\.io'` clean; descriptive references only).
- [x] Content-preservation cross-check — every concept from the old single file appears in at least one of the two new files (`grep -l` over 23 key terms).
- [x] No status-log content (no PR-number references, dated incidents, or "fixed in X" rot phrasing).
- [ ] CI confirms `verifyBuildPolicy` passes the markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly expanded developer documentation with comprehensive guidance on GitHub workflows, CI/CD operations, release management procedures, dependency verification protocols, build and test conventions, security hardening requirements, resource lifecycle safety, and project architecture. Added centralized reference documentation for automated workflows, verification metadata handling, and maintenance practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->